### PR TITLE
Explicitly set the dnsdist.conf file permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   template:
     src: dnsdist.conf.j2
     dest: /etc/dnsdist/dnsdist.conf
-    mode: '0750'
+    mode: '0640'
     validate: 'dnsdist -C %s --check-config 2>&1'
   notify: restart dnsdist
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
   template:
     src: dnsdist.conf.j2
     dest: /etc/dnsdist/dnsdist.conf
+    mode: '0750'
     validate: 'dnsdist -C %s --check-config 2>&1'
   notify: restart dnsdist
   tags:


### PR DESCRIPTION
Explicitly set the dnsdist.conf file permissions since Ansible defaults to `0644` allowing unprivileged access users to read the file.