### PR TITLE
Allow to manage systemd overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.1.1 (To be released)
+
+NEW FEATURES:
+- Allow to manage systemd overrides ([\#13](https://github.com/PowerDNS/pdns-ansible/pull/13))
+
 ## v1.1.0 (2018-06-25)
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ dnsdist_config: ""
 
 Additional dnsdist configuration to be injected verbatim in the `dnsdist.conf` file.
 
+```yaml
+pdns_service_overrides: {}
+```
+
+Dict with overrides for the service (systemd only).
+This can be used to change any systemd settings in the `[Service]` category.
+
 ## Example Playbook
 
 Deploy dnsdist in front of Quad9 and enable the web monitoring interface

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,3 +87,8 @@ dnsdist_carbonserver: ""
 # Additional dnsdist configuration to be
 # injected into dnsdist's configuration file.
 dnsdist_config: ""
+
+# Dict with overrides for the service (systemd only)
+dnsdist_service_overrides: {}
+# dnsdist_service_overrides:
+#   LimitNOFILE: 10000

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
   service:
     name: dnsdist
     state: restarted
+
+- name: reload systemd and restart dnsdist
+  command: systemctl daemon-reload
+  notify: restart dnsdist

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,7 @@ galaxy_info:
         - vivid
         - wily
         - xenial
+        - bionic
   galaxy_tags:
     - dnsdist
     - dns

--- a/molecule/dnsdist-13/molecule.yml
+++ b/molecule/dnsdist-13/molecule.yml
@@ -30,6 +30,7 @@ platforms:
 
   - name: ubuntu-1804
     image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
     groups:
       - dnsdist
 

--- a/molecule/dnsdist-13/molecule.yml
+++ b/molecule/dnsdist-13/molecule.yml
@@ -28,6 +28,11 @@ platforms:
     groups:
       - dnsdist
 
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    groups:
+      - dnsdist
+
   - name: debian-9
     image: debian:9
     dockerfile_tpl: debian-systemd
@@ -45,6 +50,9 @@ provisioner:
     prepare: ../resources/prepare.yml
   lint:
     name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
 
 lint:
   name: yamllint

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -30,6 +30,7 @@ platforms:
 
   - name: ubuntu-1804
     image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
     groups:
       - dnsdist
 

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -28,6 +28,11 @@ platforms:
     groups:
       - dnsdist
 
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    groups:
+      - dnsdist
+
   - name: debian-9
     image: debian:9
     dockerfile_tpl: debian-systemd
@@ -45,6 +50,9 @@ provisioner:
     prepare: ../resources/prepare.yml
   lint:
     name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
 
 lint:
   name: yamllint

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -35,3 +35,15 @@ def test_service(host):
     s = host.ansible('service', 'name=dnsdist state=started enabled=yes')
 
     assert s["changed"] is False
+
+
+def systemd_override(host):
+    smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
+    if smgr == 'systemd':
+        fname = '/etc/systemd/system/pdns.service.d/override.conf'
+        f = host.file(fname)
+
+        assert f.exists
+        assert f.user == 'root'
+        assert f.group == 'root'
+        assert 'LimitCORE=infinity' in f.content

--- a/molecule/resources/vars/dnsdist-common.yml
+++ b/molecule/resources/vars/dnsdist-common.yml
@@ -5,3 +5,6 @@
 ##
 
 dnsdist_install_debug_symbols_package: True
+
+dnsdist_service_overrides:
+  LimitCORE: infinity

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,31 @@
+---
+
+- block:
+
+  - name: Ensure the override directory exists (systemd)
+    file:
+      name: "/etc/systemd/system/dnsdist.service.d"
+      state: directory
+      owner: root
+      group: root
+
+  - name: Override the dnsdist unit (systemd)
+    template:
+      src: "override-service.systemd.conf.j2"
+      dest: "/etc/systemd/system/dnsdist.service.d/override.conf"
+      owner: root
+      group: root
+    notify: reload systemd and restart dnsdist
+
+  when: dnsdist_service_overrides != {}
+    and ansible_service_mgr == "systemd"
+
+- name: Add the dnsdist configuration
+  template:
+    src: dnsdist.conf.j2
+    dest: /etc/dnsdist/dnsdist.conf
+    owner: "root"
+    group: "root"
+    mode: 0640
+    validate: dnsdist -C %s --check-config 2>&1
+  notify: restart dnsdist

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,15 +15,7 @@
   tags:
     - install
 
-- name: Add the dnsdist configuration
-  template:
-    src: dnsdist.conf.j2
-    dest: /etc/dnsdist/dnsdist.conf
-    owner: "root"
-    group: "root"
-    mode: 0640
-    validate: dnsdist -C %s --check-config 2>&1
-  notify: restart dnsdist
+- include: configure.yml
   tags:
     - configure
 

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for k, v in dnsdist_service_overrides.items() %}
+{{ k }}={{ v }}
+{% endfor %}


### PR DESCRIPTION
This PR 
- implements a new option to configure systemd overrides (e.g. to enable coredumps).
- extends the test suite to Bionic