### PR TITLE
Allow to optionally disable handlers execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 NEW FEATURES:
 - Allow to manage systemd overrides ([\#13](https://github.com/PowerDNS/pdns-ansible/pull/13))
+- Add an option (`dnsdist_disable_handlers`) to disable the automated restart of the service on configuration changes ([\#14](https://github.com/PowerDNS/dnsdist-ansible/pull/14))
 
 ## v1.1.0 (2018-06-25)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ dnsdist_service_overrides: {}
 Dict with overrides for the service (systemd only).
 This can be used to change any systemd settings in the `[Service]` category.
 
+```yaml
+dnsdist_disable_handlers: False
+```
+
+Disable automated service restart on configuration changes.
+
 ## Example Playbook
 
 Deploy dnsdist in front of Quad9 and enable the web monitoring interface

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,3 +92,6 @@ dnsdist_config: ""
 dnsdist_service_overrides: {}
 # dnsdist_service_overrides:
 #   LimitNOFILE: 10000
+
+# When True, disable the automated restart of the dnsdist service
+dnsdist_disable_handlers: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,10 @@
   service:
     name: dnsdist
     state: restarted
+    sleep: 1                          # the sleep is needed to make sure the service has been
+  when: not dnsdist_disable_handlers  # correctly started after being stopped during restarts
 
 - name: reload systemd and restart dnsdist
   command: systemctl daemon-reload
   notify: restart dnsdist
+  when: not dnsdist_disable_handlers


### PR DESCRIPTION
This PR adds the `dnsdist_disable_handlers` variable to optionally disable handlers execution on configuration changes.