### PR TITLE
Add some variables to allow to configure the status of the DNSdist service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.3.0 (To be released)
+
+- Add some options (`dnsdist_service_state` and `dnsdist_service_enabled`) to configure the status of the dnsdist service ([\#15](https://github.com/PowerDNS/dnsdist-ansible/pull/15))
 ## v1.2.0 (2018-12-02)
 
 NEW FEATURES:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ Dict with overrides for the service (systemd only).
 This can be used to change any systemd settings in the `[Service]` category.
 
 ```yaml
+dnsdist_service_state: "started"
+dnsdist_service_enabled: "yes"
+```
+
+Allow to specify the desired state of the DNSdist service.
+E.g. This allows to install and configure DNSdist without automatically starting the service.
+
+```yaml
 dnsdist_disable_handlers: False
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,5 +93,9 @@ dnsdist_service_overrides: {}
 # dnsdist_service_overrides:
 #   LimitNOFILE: 10000
 
+# State of the DNSdist service
+dnsdist_service_state: "started"
+dnsdist_service_enabled: "yes"
+
 # When True, disable the automated restart of the dnsdist service
 dnsdist_disable_handlers: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,9 @@
     name: dnsdist
     state: restarted
     sleep: 1                          # the sleep is needed to make sure the service has been
-  when: not dnsdist_disable_handlers  # correctly started after being stopped during restarts
+                                      # correctly started after being stopped during restarts
+  when: dnsdist_service_state != 'stopped' and
+    not dnsdist_disable_handlers
 
 - name: reload systemd and restart dnsdist
   command: systemctl daemon-reload

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,14 @@
 ---
 
+# the sleep in the restart dnsdist handler
+# is needed to make sure the service has been
+# correctly stopped before being started again during restarts
+
 - name: restart dnsdist
   service:
     name: dnsdist
     state: restarted
-    sleep: 1                          # the sleep is needed to make sure the service has been
-                                      # correctly started after being stopped during restarts
+    sleep: 1
   when: dnsdist_service_state != 'stopped' and
     not dnsdist_disable_handlers
 

--- a/molecule/dnsdist-13/molecule.yml
+++ b/molecule/dnsdist-13/molecule.yml
@@ -22,12 +22,6 @@ platforms:
     groups:
       - dnsdist
 
-  - name: ubuntu-1710
-    image: ubuntu:17.10
-    dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
-
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -22,12 +22,6 @@ platforms:
     groups:
       - dnsdist
 
-  - name: ubuntu-1710
-    image: ubuntu:17.10
-    dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
-
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,10 +19,10 @@
   tags:
     - configure
 
-- name: Start and enable the dnsdist service
+- name: Set the status of the dnsdist service
   service:
     name: dnsdist
-    state: started
-    enabled: true
+    state: "{{ dnsdist_service_state }}"
+    enabled: "{{ dnsdist_service_enabled }}"
   tags:
     - service

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-molecule==2.14.0
+molecule==2.19.0
 docker-py==1.10.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{22,23,24,25}
+envlist = py{27}-ansible{25,26,27}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.2: ansible22
-  2.3: ansible23
-  2.4: ansible24
   2.5: ansible25
+  2.6: ansible26
+  2.7: ansible27
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible22: ansible<2.3
-    ansible23: ansible<2.4
-    ansible24: ansible<2.5
     ansible25: ansible<2.6
+    ansible26: ansible<2.7
+    ansible27: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,4 @@
 default_dnsdist_package_name: "dnsdist"
 
 # The name of the dnsdist debug package
-default_dnsdist_debug_symbols_package_name: "dnsdist-dbg"
+default_dnsdist_debug_symbols_package_name: "{% if ansible_distribution == 'Debian' and ansible_distribution_version | int < 9 or ansible_distribution == 'Ubuntu' and ansible_distribution_version <= '16.04' %}dnsdist-dbg{% else %}dnsdist-dbgsym{% endif %}"


### PR DESCRIPTION
This PR introduces to new variables `dnsdist_service_state` and `dnsdist_service_enabled` to configure the status of the DNSdist service.

A typical use-case is the installation of the DNSdist without actually starting the service automatically via Ansible.