### PR TITLE
Ensure ExecStart is properly overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ dnsdist_config: ""
 Additional dnsdist configuration to be injected verbatim in the `dnsdist.conf` file.
 
 ```yaml
+dnsdist_config_owner: 'root'
+dnsdist_config_group: 'root'
+```
+
+User and Group that own the `dnsdist.conf` file.
+
+```yaml
 dnsdist_service_overrides: {}
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,10 @@ dnsdist_carbonserver: ""
 # injected into dnsdist's configuration file.
 dnsdist_config: ""
 
+# Owner and group for /etc/dnsdist/dnsdist.conf
+dnsdist_config_owner: 'root'
+dnsdist_config_group: 'root'
+
 # Dict with overrides for the service (systemd only)
 dnsdist_service_overrides: {}
 # dnsdist_service_overrides:

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -1,3 +1,4 @@
+import re
 
 debian_os = ['debian', 'ubuntu']
 rhel_os = ['redhat', 'centos']
@@ -41,9 +42,12 @@ def systemd_override(host):
     smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
     if smgr == 'systemd':
         fname = '/etc/systemd/system/pdns.service.d/override.conf'
+        exec_start = 'ExecStart=/usr/bin/dnsdist --supervised --disable-syslog'
         f = host.file(fname)
 
         assert f.exists
         assert f.user == 'root'
         assert f.group == 'root'
         assert 'LimitCORE=infinity' in f.content
+        assert re.match(r'^ExecStart=$', f.content)
+        assert exec_start in f.content

--- a/molecule/resources/vars/dnsdist-common.yml
+++ b/molecule/resources/vars/dnsdist-common.yml
@@ -8,3 +8,4 @@ dnsdist_install_debug_symbols_package: True
 
 dnsdist_service_overrides:
   LimitCORE: infinity
+  ExecStart: '/usr/bin/dnsdist --supervised --disable-syslog'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,8 +24,8 @@
   template:
     src: dnsdist.conf.j2
     dest: /etc/dnsdist/dnsdist.conf
-    owner: "root"
-    group: "root"
+    owner: '{{ dnsdist_config_owner }}'
+    group: '{{ dnsdist_config_group }}'
     mode: 0640
     validate: dnsdist -C %s --check-config 2>&1
   notify: restart dnsdist

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,4 +23,4 @@
   package:
     name: "{{ dnsdist_debug_symbols_package_name }}{{ _dnsdist_package_version | default('') }}"
     state: present
-  when: dnsdist_install_debug_symbols_package
+  when: dnsdist_install_debug_symbols_package | bool

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,4 +1,6 @@
 [Service]
 {% for k, v in dnsdist_service_overrides.items() %}
+{% if k == 'ExecStart' %}ExecStart=
+{% endif %}
 {{ k }}={{ v }}
 {% endfor %}


### PR DESCRIPTION
Newer Ansibles don't like the 
```yaml
'ExecStart': ''
ExecStart: '/foo...'
```

Trick