### PR TITLE
Add support for setting web-interface API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ dnsdist_webserver_password: ""
 The authentication credentials fro the build-in webserver. Must be set when `dnsdist_webserver_address` is set.
 
 ```yaml
+dnsdist_webserver_apikey: ""
+```
+
+The authentication credentials for the built-in API. 
+
+
+```yaml
 dnsdist_config: ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The listen IP address of the built-in webserver, empty thus disable by default.
 dnsdist_webserver_password: ""
 ```
 
-The authentication credentials fro the build-in webserver. Must be set when `dnsdist_webserver_address` is set.
+The authentication credentials for the build-in webserver. Must be set when `dnsdist_webserver_address` is set.
 
 ```yaml
 dnsdist_webserver_apikey: ""

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The listen IP address of the built-in webserver, empty thus disable by default.
 dnsdist_webserver_password: ""
 ```
 
-The authentication credentials for the build-in webserver. Must be set when `dnsdist_webserver_address` is set.
+The authentication credentials for the built-in webserver. Must be set when `dnsdist_webserver_address` is set.
 
 ```yaml
 dnsdist_webserver_apikey: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,9 @@ dnsdist_webserver_address: ""
 # Embedded webserver authentication password.
 dnsdist_webserver_password: ""
 
+# Embedded webserver authentication API-key.
+dnsdist_webserver_apikey: ""
+
 # Remote Carbon server for metrics exporting.
 # See https://dnsdist.org/guides/carbon.html for more details.
 dnsdist_carbonserver: ""

--- a/templates/dnsdist.conf.j2
+++ b/templates/dnsdist.conf.j2
@@ -22,7 +22,11 @@ setKey("{{dnsdist_setkey}}")
 {% endif %}
 
 {% if dnsdist_webserver_address != "" and dnsdist_webserver_password != "" %}
+{% if dnsdist_webserver_apikey == "" %}
 webserver("{{ dnsdist_webserver_address }}", "{{ dnsdist_webserver_password }}")
+{% else %}
+webserver("{{ dnsdist_webserver_address }}", "{{ dnsdist_webserver_password }}", "{{ dnsdist_webserver_apikey }}")
+{% endif %}
 {% endif %}
 
 {% if dnsdist_carbonserver != "" %}


### PR DESCRIPTION
This PR adds support for setting the web-interface API key.
If it is not entered, there is no API key added.