### PR TITLE
Set the encryption key to a random value if it is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ dnsdist_config: ""
 Additional dnsdist configuration to be injected verbatim in the `dnsdist.conf` file.
 
 ```yaml
+dnsdist_config_owner: 'root'
+dnsdist_config_group: 'root'
+```
+
+User and Group that own the `dnsdist.conf` file.
+
+```yaml
 dnsdist_service_overrides: {}
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The listen IP address of the dnsdist's TCP control socket.
 dnsdist_setkey: ""
 ```
 
-Encryption key for the dnsdist's TCP control socket.
+Encryption key for the dnsdist's TCP control socket. If it is empty, a random key will be generated. If a key is already present in the file, it will be kept.
 
 ```yaml
 dnsdist_webserver_address: ""

--- a/README.md
+++ b/README.md
@@ -136,7 +136,14 @@ The listen IP address of the built-in webserver, empty thus disable by default.
 dnsdist_webserver_password: ""
 ```
 
-The authentication credentials fro the build-in webserver. Must be set when `dnsdist_webserver_address` is set.
+The authentication credentials for the built-in webserver. Must be set when `dnsdist_webserver_address` is set.
+
+```yaml
+dnsdist_webserver_apikey: ""
+```
+
+The authentication credentials for the built-in API. 
+
 
 ```yaml
 dnsdist_config: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,7 +69,7 @@ dnsdist_acls: []
 
 # dnsdist's control socket encryption key.
 # See https://dnsdist.org/reference/config.html#setKey for more information.
-dnsdist_setkey: ""
+dnsdist_generatekey: "{{ (dnsdist_setkey is defined)|bool and (dnsdist_setkey|length == 0 )|bool }}"
 
 # dnsdist's control socket list address.
 dnsdist_controlsocket: "127.0.0.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,10 @@ dnsdist_carbonserver: ""
 # injected into dnsdist's configuration file.
 dnsdist_config: ""
 
+# Owner and group for /etc/dnsdist/dnsdist.conf
+dnsdist_config_owner: 'root'
+dnsdist_config_group: 'root'
+
 # Dict with overrides for the service (systemd only)
 dnsdist_service_overrides: {}
 # dnsdist_service_overrides:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,9 @@ dnsdist_webserver_address: ""
 # Embedded webserver authentication password.
 dnsdist_webserver_password: ""
 
+# Embedded webserver authentication API-key.
+dnsdist_webserver_apikey: ""
+
 # Remote Carbon server for metrics exporting.
 # See https://dnsdist.org/guides/carbon.html for more details.
 dnsdist_carbonserver: ""

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -1,3 +1,4 @@
+import re
 
 debian_os = ['debian', 'ubuntu']
 rhel_os = ['redhat', 'centos']
@@ -41,9 +42,12 @@ def systemd_override(host):
     smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
     if smgr == 'systemd':
         fname = '/etc/systemd/system/pdns.service.d/override.conf'
+        exec_start = 'ExecStart=/usr/bin/dnsdist --supervised --disable-syslog'
         f = host.file(fname)
 
         assert f.exists
         assert f.user == 'root'
         assert f.group == 'root'
         assert 'LimitCORE=infinity' in f.content
+        assert re.match(r'^ExecStart=$', f.content)
+        assert exec_start in f.content

--- a/molecule/resources/vars/dnsdist-common.yml
+++ b/molecule/resources/vars/dnsdist-common.yml
@@ -8,3 +8,4 @@ dnsdist_install_debug_symbols_package: True
 
 dnsdist_service_overrides:
   LimitCORE: infinity
+  ExecStart: '/usr/bin/dnsdist --supervised --disable-syslog'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,8 +24,8 @@
   template:
     src: dnsdist.conf.j2
     dest: /etc/dnsdist/dnsdist.conf
-    owner: "root"
-    group: "root"
+    owner: '{{ dnsdist_config_owner }}'
+    group: '{{ dnsdist_config_group }}'
     mode: 0640
     validate: dnsdist -C %s --check-config 2>&1
   notify: restart dnsdist

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,4 +23,4 @@
   package:
     name: "{{ dnsdist_debug_symbols_package_name }}{{ _dnsdist_package_version | default('') }}"
     state: present
-  when: dnsdist_install_debug_symbols_package
+  when: dnsdist_install_debug_symbols_package | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,8 @@
         - name: base64 encode encyption key
           set_fact:
             dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
-      when: "dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0" # if the config file does not contains a key already
+      # if the config file does not contains a key already
+      when: "dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0"
     - block:
         - name: Set old encryption key
           set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,20 @@
   tags:
     - install
 
+- name: Create encryption key
+  block:
+#    shell: "{{ ansible_python_interpreter }} -c 'import base64; import secrets; print(\"{}\".format(base64.b64encode(secrets.token_bytes(32)).decode(\"utf-8\")))'"
+    - name: Generate encryption key
+      shell: head -c 32 /dev/urandom | base64
+      register: dnsdist_setkey_cmd
+    - name: base64 encode encyption key
+      set_fact:
+        dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
+  when: dnsdist_setkey == ""
+  tags:
+    - install
+    - configure
+
 - include: configure.yml
   tags:
     - configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,18 +17,27 @@
 
 - name: Create encryption key
   block:
-    - name: Generate encryption key
-      shell: head -c 32 /dev/urandom | base64
-      register: dnsdist_setkey_cmd
-    - name: base64 encode encyption key
-      set_fact:
-        dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
-    - name: Register key to file
-      copy:
-        content: "{{ dnsdist_setkey_cmd.stdout }}"
-        dest: "./{{ ansible_inventory_hostname }}.key"
-      delegate_to: localhost
-  when: dnsdist_setkey == ""
+    - name: Check if the key is already present in the DNSdist configuration file
+      shell: fgrep setKey "{{ default_dnsdist_config_location }}" | sed 's/setKey("\(.*\)")/\1/'
+      register: dnsdist_grepkey_cmd
+      changed_when: false
+      failed_when: false
+
+    - block:
+        - name: Generate encryption key
+          shell: head -c 32 /dev/urandom | base64
+          register: dnsdist_setkey_cmd
+
+        - name: base64 encode encyption key
+          set_fact:
+            dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
+      when: "dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0" # if the config file does not contains a key already
+    - block:
+        - name: Set old encryption key
+          set_fact:
+            dnsdist_setkey: "{{ dnsdist_grepkey_cmd.stdout }}"
+      when: "dnsdist_grepkey_cmd.rc == 0 and dnsdist_grepkey_cmd.stdout | length > 0"
+  when: dnsdist_generatekey
   tags:
     - install
     - configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,13 +17,17 @@
 
 - name: Create encryption key
   block:
-#    shell: "{{ ansible_python_interpreter }} -c 'import base64; import secrets; print(\"{}\".format(base64.b64encode(secrets.token_bytes(32)).decode(\"utf-8\")))'"
     - name: Generate encryption key
       shell: head -c 32 /dev/urandom | base64
       register: dnsdist_setkey_cmd
     - name: base64 encode encyption key
       set_fact:
         dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
+    - name: Register key to file
+      copy:
+        content: "{{ dnsdist_setkey_cmd.stdout }}"
+        dest: "./{{ ansible_inventory_hostname }}.key"
+      delegate_to: localhost
   when: dnsdist_setkey == ""
   tags:
     - install

--- a/templates/dnsdist.conf.j2
+++ b/templates/dnsdist.conf.j2
@@ -22,7 +22,11 @@ setKey("{{dnsdist_setkey}}")
 {% endif %}
 
 {% if dnsdist_webserver_address != "" and dnsdist_webserver_password != "" %}
+{% if dnsdist_webserver_apikey == "" %}
 webserver("{{ dnsdist_webserver_address }}", "{{ dnsdist_webserver_password }}")
+{% else %}
+webserver("{{ dnsdist_webserver_address }}", "{{ dnsdist_webserver_password }}", "{{ dnsdist_webserver_apikey }}")
+{% endif %}
 {% endif %}
 
 {% if dnsdist_carbonserver != "" %}

--- a/templates/dnsdist.conf.j2
+++ b/templates/dnsdist.conf.j2
@@ -17,7 +17,7 @@ newServer("{{server}}")
 {% if dnsdist_controlsocket != "" %}
 controlSocket("{{ dnsdist_controlsocket }}")
 {% endif %}
-{% if dnsdist_setkey != "" %}
+{% if dnsdist_setkey is defined and dnsdist_setkey != "" %}
 setKey("{{dnsdist_setkey}}")
 {% endif %}
 

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,4 +1,6 @@
 [Service]
 {% for k, v in dnsdist_service_overrides.items() %}
+{% if k == 'ExecStart' %}ExecStart=
+{% endif %}
 {{ k }}={{ v }}
 {% endfor %}


### PR DESCRIPTION
This should fix the issue in https://github.com/PowerDNS/dnsdist-ansible/issues/2
I encountered a similar problem when trying to install a new copy of dnsdist. 

I have not found a good solution how to collect the generated secret, but this might not be necessary for the cases when random one is generated.