### PR TITLE
Add dnsdist 1.5 repos

### DIFF
--- a/molecule/dnsdist-15/molecule.yml
+++ b/molecule/dnsdist-15/molecule.yml
@@ -1,0 +1,65 @@
+---
+
+scenario:
+  name: dnsdist-15
+
+driver:
+  name: docker
+
+dependency:
+  name: galaxy
+
+platforms:
+  - name: centos-7
+    image: centos:7
+    dockerfile_tpl: centos-systemd
+    groups:
+      - dnsdist
+
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+  - name: ubuntu-2004
+    image: ubuntu:20.04
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+  - name: debian-10
+    image: debian:10
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+provisioner:
+  name: ansible
+  options:
+    diff: True
+    v: True
+  playbooks:
+    create: ../resources/create.yml
+    destroy: ../resources/destroy.yml
+    prepare: ../resources/prepare.yml
+  lint:
+    name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
+
+lint:
+  name: yamllint
+
+verifier:
+  name: testinfra
+  options:
+    hosts: "dnsdist"
+    vvv: True
+  directory: ../resources/tests/all
+  additional_files_or_dirs:
+    # path relative to 'directory'
+    - ../repo-15/
+  lint:
+    name: flake8

--- a/molecule/dnsdist-15/playbook.yml
+++ b/molecule/dnsdist-15/playbook.yml
@@ -1,0 +1,8 @@
+---
+
+- hosts: dnsdist
+  vars_files:
+    - ../resources/vars/dnsdist-common.yml
+    - ../resources/vars/dnsdist-repo-15.yml
+  roles:
+    - { role: dnsdist-ansible }

--- a/molecule/resources/tests/repo-15/test_repo_15.py
+++ b/molecule/resources/tests/repo-15/test_repo_15.py
@@ -1,0 +1,32 @@
+
+debian_os = ['debian', 'ubuntu']
+rhel_os = ['redhat', 'centos']
+
+
+def test_repo_file(host):
+    f = None
+    if host.system_info.distribution.lower() in debian_os:
+        f = host.file('/etc/apt/sources.list.d/powerdns-dnsdist-15.list')
+    if host.system_info.distribution.lower() in rhel_os:
+        f = host.file('/etc/yum.repos.d/powerdns-dnsdist-15.repo')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+
+
+def test_pdns_repo(host):
+    f = None
+    if host.system_info.distribution.lower() in debian_os:
+        f = host.file('/etc/apt/sources.list.d/powerdns-dnsdist-15.list')
+    if host.system_info.distribution.lower() in rhel_os:
+        f = host.file('/etc/yum.repos.d/powerdns-dnsdist-15.repo')
+
+    assert f.exists
+    assert f.contains('dnsdist-15')
+
+
+def test_pdns_version(host):
+    cmd = host.run('/usr/bin/dnsdist --version')
+
+    assert 'dnsdist 1.5' in cmd.stdout

--- a/molecule/resources/vars/dnsdist-repo-15.yml
+++ b/molecule/resources/vars/dnsdist-repo-15.yml
@@ -1,0 +1,9 @@
+---
+
+##
+# Dnsdist 1.5.x Repository
+##
+
+dnsdist_install_repo: "{{ dnsdist_powerdns_repo_15 }}"
+
+dnsdist_install_debug_symbols_package: False

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -53,3 +53,12 @@ dnsdist_powerdns_repo_14:
   yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14"
   yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14/debug"
   name: "powerdns-dnsdist-14"
+
+dnsdist_powerdns_repo_15:
+  apt_repo_origin: "repo.powerdns.com"
+  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-15 main"
+  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
+  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15"
+  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15/debug"
+  name: "powerdns-dnsdist-15"


### PR DESCRIPTION
Hi! I added `dnsdist_powerdns_repo_15`
Also, I replaced ubuntu `16.04` with `20.04` and debian `9` with `10` in molecule.
I had to disable `dnsdist_install_debug_symbols_package` because `dnsdist-dbgsym` package is not available neither in http://repo.powerdns.com/ubuntu/dists/focal-dnsdist-15/main/binary-amd64/Packages nor in http://repo.powerdns.com/ubuntu/dists/bionic-dnsdist-15/main/binary-amd64/Packages