### PR TITLE
Enable downgrading through forced reinstall flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ dnsdist_tlslocals: []
 ```
 Configures DNS over TLS listeners. The entries are copied verbatim entry-by-entry.
 
+```yaml
+dnsdist_force_reinstall: False
+```
+
+Force reinstall of dnsdist packages by performing a removal prior to the package installation steps. Intended for usage where a downgrade of dnsdist needs to be performed.
+
 ## Example Playbook
 
 Deploy dnsdist in front of Quad9 and enable the web monitoring interface

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,8 @@ dnsdist_disable_handlers: False
 # When set, adds a DNS over TLS frontend
 dnsdist_tlslocals: []
 
-# When set to True, remove dnsdist packages and force an install
-# Allows for rollbacks to previous versions using Ansible's generic 'package' module
+# When set to True, remove dnsdist packages and force a reinstall
+# Not recommended for regular usage; Primarily intended for 2 scenario's:
+# - Force a downgrade
+# - Automation of test scenario's where switching between versions on the same server is necessary
 dnsdist_force_reinstall: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,3 +109,7 @@ dnsdist_disable_handlers: False
 
 # When set, adds a DNS over TLS frontend
 dnsdist_tlslocals: []
+
+# When set to True, remove dnsdist packages and force an install
+# Allows for rollbacks to previous versions using Ansible's generic 'package' module
+dnsdist_force_reinstall: False

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,6 +14,18 @@
 
   when: dnsdist_package_version != ''
 
+- name: Remove dnsdist
+  package:
+    name: "{{ dnsdist_package_name }}"
+    state: absent
+  when: dnsdist_force_reinstall | bool
+
+- name: Remove dnsdist debug symbols
+  package:
+    name: "{{ dnsdist_debug_symbols_package_name }}"
+    state: absent
+  when: dnsdist_force_reinstall | bool
+
 - name: Install dnsdist
   package:
     name: "{{ dnsdist_package_name }}{{ _dnsdist_package_version | default('') }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,13 +14,13 @@
 
   when: dnsdist_package_version != ''
 
-- name: Remove dnsdist
+- name: Remove dnsdist if reinstall is forced
   package:
     name: "{{ dnsdist_package_name }}"
     state: absent
   when: dnsdist_force_reinstall | bool
 
-- name: Remove dnsdist debug symbols
+- name: Remove dnsdist debug symbols if reinstall is forced
   package:
     name: "{{ dnsdist_debug_symbols_package_name }}"
     state: absent


### PR DESCRIPTION
Current playbook uses Ansible's 'package' module to install/upgrade packages, which does not allow to downgrade. This 'dnsdist_force_reinstall' flag will allow a user to force removal of existing dnsdist packages so that any version can then be installed.

Note: Considered using the 'yum' and 'apt' modules with 'allow downgrade' flags to achieve this, but that seemed undesirable as it would open the possibility for accidental downgrades.