### PR TITLE
Dnsdist 1.5 support + updated test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,43 @@
 ---
 
+os: linux
+dist: focal
 language: python
-python: 2.7
-
-sudo: required
+python: 3.6
 
 # Enable the docker service
 services:
   - docker
 
+# Replace aufs with the vfs docker storage driver
+# to prevent systemd to fail starting docker in docker.
+before_install:
+  - sudo sed -i 's|DOCKER_OPTS=.*|DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock --storage-driver vfs"|g' /etc/default/docker
+  - sudo service docker restart
+  - docker info
+
 # Parallel testing of the supported
 # Ansible versions
 env:
-  matrix:
-    - ANSIBLE=2.5
-    - ANSIBLE=2.6
-    - ANSIBLE=2.7
+  jobs:
+    - ANSIBLE=2.7 DNSDIST_VERSION=13
+    - ANSIBLE=2.7 DNSDIST_VERSION=14
+    - ANSIBLE=2.7 DNSDIST_VERSION=15
+    - ANSIBLE=2.7 DNSDIST_VERSION=master
+
+    - ANSIBLE=2.8 DNSDIST_VERSION=13
+    - ANSIBLE=2.8 DNSDIST_VERSION=14
+    - ANSIBLE=2.8 DNSDIST_VERSION=15
+    - ANSIBLE=2.8 DNSDIST_VERSION=master
+
+    - ANSIBLE=2.9 DNSDIST_VERSION=13
+    - ANSIBLE=2.9 DNSDIST_VERSION=14
+    - ANSIBLE=2.9 DNSDIST_VERSION=15
+    - ANSIBLE=2.9 DNSDIST_VERSION=master
+
+jobs:
+  allow_failures:
+    - env: DNSDIST_VERSION=master
 
 # Install tox
 install:
@@ -23,7 +45,7 @@ install:
 
 # Test the current Dnsdist stable release
 script:
-  - tox -- molecule test -s dnsdist-13
+  - tox -- molecule test -s dnsdist-${DNSDIST_VERSION}
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ To test all the scenarios run
 
 To run a custom molecule command
 
-    $ tox -e py27-ansible22 -- molecule test -s dnsdist-13
+    $ tox -e py36-ansible29 -- molecule test -s dnsdist-15
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ dnsdist_install_repo: ""
 #        dnsdist_install_repo: "{{ dnsdist_powerdns_repo_13 }}"
 #
 # To install dnsdist from a custom repository
-# override the `dnsdist_install_install_repo` default value in your playbook.
+# override the `dnsdist_install_repo` default value in your playbook.
 # e.g.
 # - hosts: all
 #   vars:
@@ -92,8 +92,8 @@ dnsdist_carbonserver: ""
 dnsdist_config: ""
 
 # Owner and group for /etc/dnsdist/dnsdist.conf
-dnsdist_config_owner: 'root'
-dnsdist_config_group: 'root'
+dnsdist_config_owner: ""
+dnsdist_config_group: ""
 
 # Dict with overrides for the service (systemd only)
 dnsdist_service_overrides: {}

--- a/molecule/dnsdist-13/converge.yml
+++ b/molecule/dnsdist-13/converge.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: dnsdist
+- hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-13.yml

--- a/molecule/dnsdist-13/molecule.yml
+++ b/molecule/dnsdist-13/molecule.yml
@@ -13,53 +13,41 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1604
     image: ubuntu:16.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: debian-9
     image: debian:9
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
 provisioner:
   name: ansible
   options:
     diff: True
     v: True
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint:
-    name: ansible-lint
-    options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
 
-lint:
-  name: yamllint
+lint: yamllint vars tasks defaults meta
 
 verifier:
   name: testinfra
   options:
-    hosts: "dnsdist"
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-13/
-  lint:
-    name: flake8
+  lint: flake8

--- a/molecule/dnsdist-14/converge.yml
+++ b/molecule/dnsdist-14/converge.yml
@@ -1,8 +1,8 @@
 ---
 
-- hosts: dnsdist
+- hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
-    - ../resources/vars/dnsdist-repo-15.yml
+    - ../resources/vars/dnsdist-repo-14.yml
   roles:
     - { role: dnsdist-ansible }

--- a/molecule/dnsdist-14/molecule.yml
+++ b/molecule/dnsdist-14/molecule.yml
@@ -13,53 +13,41 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1604
     image: ubuntu:16.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: debian-9
     image: debian:9
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
 provisioner:
   name: ansible
   options:
     diff: True
     v: True
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint:
-    name: ansible-lint
-    options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
 
-lint:
-  name: yamllint
+lint: yamllint vars tasks defaults meta
 
 verifier:
   name: testinfra
   options:
-    hosts: "dnsdist"
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-14/
-  lint:
-    name: flake8
+  lint: flake8

--- a/molecule/dnsdist-15/converge.yml
+++ b/molecule/dnsdist-15/converge.yml
@@ -1,8 +1,8 @@
 ---
 
-- hosts: dnsdist
+- hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
-    - ../resources/vars/dnsdist-repo-14.yml
+    - ../resources/vars/dnsdist-repo-15.yml
   roles:
     - { role: dnsdist-ansible }

--- a/molecule/dnsdist-15/molecule.yml
+++ b/molecule/dnsdist-15/molecule.yml
@@ -13,53 +13,49 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - dnsdist
+
+  - name: centos-8
+    image: centos:8
+    dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-2004
     image: ubuntu:20.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
+
+  - name: debian-9
+    image: debian:9
+    dockerfile_tpl: debian-systemd
 
   - name: debian-10
     image: debian:10
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
 provisioner:
   name: ansible
   options:
     diff: True
     v: True
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint:
-    name: ansible-lint
-    options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
 
-lint:
-  name: yamllint
+lint: yamllint vars tasks defaults meta
 
 verifier:
   name: testinfra
   options:
-    hosts: "dnsdist"
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-15/
-  lint:
-    name: flake8
+  lint: flake8

--- a/molecule/dnsdist-15/molecule.yml
+++ b/molecule/dnsdist-15/molecule.yml
@@ -1,0 +1,65 @@
+---
+
+scenario:
+  name: dnsdist-15
+
+driver:
+  name: docker
+
+dependency:
+  name: galaxy
+
+platforms:
+  - name: centos-7
+    image: centos:7
+    dockerfile_tpl: centos-systemd
+    groups:
+      - dnsdist
+
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+  - name: ubuntu-2004
+    image: ubuntu:20.04
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+  - name: debian-10
+    image: debian:10
+    dockerfile_tpl: debian-systemd
+    groups:
+      - dnsdist
+
+provisioner:
+  name: ansible
+  options:
+    diff: True
+    v: True
+  playbooks:
+    create: ../resources/create.yml
+    destroy: ../resources/destroy.yml
+    prepare: ../resources/prepare.yml
+  lint:
+    name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
+
+lint:
+  name: yamllint
+
+verifier:
+  name: testinfra
+  options:
+    hosts: "dnsdist"
+    vvv: True
+  directory: ../resources/tests/all
+  additional_files_or_dirs:
+    # path relative to 'directory'
+    - ../repo-15/
+  lint:
+    name: flake8

--- a/molecule/dnsdist-15/playbook.yml
+++ b/molecule/dnsdist-15/playbook.yml
@@ -1,0 +1,8 @@
+---
+
+- hosts: dnsdist
+  vars_files:
+    - ../resources/vars/dnsdist-common.yml
+    - ../resources/vars/dnsdist-repo-15.yml
+  roles:
+    - { role: dnsdist-ansible }

--- a/molecule/dnsdist-master/converge.yml
+++ b/molecule/dnsdist-master/converge.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: dnsdist
+- hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-master.yml

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -14,16 +14,24 @@ platforms:
     image: centos:7
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-1604
-    image: ubuntu:16.04
-    dockerfile_tpl: debian-systemd
+  - name: centos-8
+    image: centos:8
+    dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
 
+  - name: ubuntu-2004
+    image: ubuntu:20.04
+    dockerfile_tpl: debian-systemd
+
   - name: debian-9
     image: debian:9
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-10
+    image: debian:10
     dockerfile_tpl: debian-systemd
 
 provisioner:

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -13,53 +13,41 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1604
     image: ubuntu:16.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: ubuntu-1804
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
   - name: debian-9
     image: debian:9
     dockerfile_tpl: debian-systemd
-    groups:
-      - dnsdist
 
 provisioner:
   name: ansible
   options:
     diff: True
     v: True
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint:
-    name: ansible-lint
-    options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
 
-lint:
-  name: yamllint
+lint: yamllint vars tasks defaults meta
 
 verifier:
   name: testinfra
   options:
-    hosts: "dnsdist"
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-master/
-  lint:
-    name: flake8
+  lint: flake8

--- a/molecule/resources/Dockerfile.centos-systemd.j2
+++ b/molecule/resources/Dockerfile.centos-systemd.j2
@@ -22,5 +22,6 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/usr/sbin/init"]
 
-RUN if [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf net-tools bash && dnf clean all; \
+RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl net-tools bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; fi

--- a/molecule/resources/host_vars/centos-8.yml
+++ b/molecule/resources/host_vars/centos-8.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_python_interpreter: "/usr/bin/python3"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: Prepare the Molecule Test Resources
-  hosts: dnsdist
+  hosts: all
   tasks: []

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -1,3 +1,5 @@
+import re
+
 debian_os = ['debian', 'ubuntu']
 rhel_os = ['redhat', 'centos']
 
@@ -42,3 +44,24 @@ def test_tcp(host):
 def test_udp(host):
     udp = host.socket('udp://127.0.0.1:5300')
     assert udp.is_listening
+
+
+def test_service_overrides(host):
+    smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
+    if smgr == 'systemd':
+        fname = '/etc/systemd/system/dnsdist.service.d/override.conf'
+        f = host.file(fname)
+
+        assert f.exists
+
+        f_string = f.content.decode()
+
+        assert re.search(r'^LimitCORE=infinity$', f_string, re.MULTILINE) is not None
+
+        # # Ensure a ExecStart override is preceeded by a 'ExecStart=' reset instruction
+        if re.search(r'^ExecStart=.+$', f_string, re.MULTILINE) is not None:
+            assert re.search(r'^ExecStart=$(\r?\n)^ExecStart=.+$', f_string, re.MULTILINE) is not None
+        
+        # # Ensure a ExecStartPre override is preceeded by a 'ExecStartPre=' reset instruction
+        if re.search(r'^ExecStartPre=.+$', f_string, re.MULTILINE) is not None:
+            assert re.search(r'^ExecStartPre=$(\r?\n)^ExecStartPre=.+$', f_string, re.MULTILINE) is not None

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -1,5 +1,3 @@
-import re
-
 debian_os = ['debian', 'ubuntu']
 rhel_os = ['redhat', 'centos']
 
@@ -27,8 +25,6 @@ def test_package(host):
 def test_configuration(host):
     f = host.file('/etc/dnsdist/dnsdist.conf')
     assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
 
 
 def test_service(host):
@@ -38,16 +34,11 @@ def test_service(host):
     assert s["changed"] is False
 
 
-def systemd_override(host):
-    smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
-    if smgr == 'systemd':
-        fname = '/etc/systemd/system/pdns.service.d/override.conf'
-        exec_start = 'ExecStart=/usr/bin/dnsdist --supervised --disable-syslog'
-        f = host.file(fname)
+def test_tcp(host):
+    tcp = host.socket('tcp://127.0.0.1:5300')
+    assert tcp.is_listening
 
-        assert f.exists
-        assert f.user == 'root'
-        assert f.group == 'root'
-        assert 'LimitCORE=infinity' in f.content
-        assert re.match(r'^ExecStart=$', f.content)
-        assert exec_start in f.content
+
+def test_udp(host):
+    udp = host.socket('udp://127.0.0.1:5300')
+    assert udp.is_listening

--- a/molecule/resources/tests/repo-15/test_repo_15.py
+++ b/molecule/resources/tests/repo-15/test_repo_15.py
@@ -1,0 +1,32 @@
+
+debian_os = ['debian', 'ubuntu']
+rhel_os = ['redhat', 'centos']
+
+
+def test_repo_file(host):
+    f = None
+    if host.system_info.distribution.lower() in debian_os:
+        f = host.file('/etc/apt/sources.list.d/powerdns-dnsdist-15.list')
+    if host.system_info.distribution.lower() in rhel_os:
+        f = host.file('/etc/yum.repos.d/powerdns-dnsdist-15.repo')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+
+
+def test_pdns_repo(host):
+    f = None
+    if host.system_info.distribution.lower() in debian_os:
+        f = host.file('/etc/apt/sources.list.d/powerdns-dnsdist-15.list')
+    if host.system_info.distribution.lower() in rhel_os:
+        f = host.file('/etc/yum.repos.d/powerdns-dnsdist-15.repo')
+
+    assert f.exists
+    assert f.contains('dnsdist-15')
+
+
+def test_pdns_version(host):
+    cmd = host.run('/usr/bin/dnsdist --version')
+
+    assert 'dnsdist 1.5' in cmd.stdout

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -1,3 +1,4 @@
+import re
 
 debian_os = ['debian', 'ubuntu']
 rhel_os = ['redhat', 'centos']
@@ -29,4 +30,4 @@ def test_dnsdist_repo(host):
 def test_dnsdist_version(host):
     cmd = host.run('/usr/bin/dnsdist --version')
 
-    assert 'dnsdist 0.0.' in cmd.stdout
+    assert re.match('dnsdist \d\.\d\.', cmd.stdout)

--- a/molecule/resources/vars/dnsdist-common.yml
+++ b/molecule/resources/vars/dnsdist-common.yml
@@ -8,4 +8,3 @@ dnsdist_install_debug_symbols_package: True
 
 dnsdist_service_overrides:
   LimitCORE: infinity
-  ExecStart: '/usr/bin/dnsdist --supervised --disable-syslog'

--- a/molecule/resources/vars/dnsdist-repo-15.yml
+++ b/molecule/resources/vars/dnsdist-repo-15.yml
@@ -5,5 +5,3 @@
 ##
 
 dnsdist_install_repo: "{{ dnsdist_powerdns_repo_15 }}"
-
-dnsdist_install_debug_symbols_package: False

--- a/molecule/resources/vars/dnsdist-repo-15.yml
+++ b/molecule/resources/vars/dnsdist-repo-15.yml
@@ -1,0 +1,9 @@
+---
+
+##
+# Dnsdist 1.5.x Repository
+##
+
+dnsdist_install_repo: "{{ dnsdist_powerdns_repo_15 }}"
+
+dnsdist_install_debug_symbols_package: False

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,20 +1,21 @@
 ---
 
+
 - block:
 
   - name: Ensure the override directory exists (systemd)
     file:
       name: "/etc/systemd/system/dnsdist.service.d"
       state: directory
-      owner: "{{ default_dnsdist_owner }}"
-      group: "{{ default_dnsdist_group }}"
+      owner: "{{ _dnsdist_owner }}"
+      group: "{{ _dnsdist_group }}"
 
   - name: Override the dnsdist unit (systemd)
     template:
       src: "override-service.systemd.conf.j2"
       dest: "/etc/systemd/system/dnsdist.service.d/override.conf"
-      owner: "{{ default_dnsdist_owner }}"
-      group: "{{ default_dnsdist_group }}"
+      owner: "{{ _dnsdist_owner }}"
+      group: "{{ _dnsdist_group }}"
     notify: reload systemd and restart dnsdist
 
   when: dnsdist_service_overrides != {}
@@ -24,8 +25,8 @@
   template:
     src: dnsdist.conf.j2
     dest: "{{ default_dnsdist_config_location }}"
-    owner: "{{ default_dnsdist_owner }}"
-    group: "{{ default_dnsdist_group }}"
+    owner: "{{ _dnsdist_owner }}"
+    group: "{{ _dnsdist_group }}"
     mode: 0640
     validate: dnsdist -C %s --check-config 2>&1
   notify: restart dnsdist

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,10 @@
     - install
     - configure
 
+- include: prepare.yml
+  tags:
+    - configure
+
 - include: configure.yml
   tags:
     - configure

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,0 +1,56 @@
+---
+# Version-related steps regarding user & group ownership to ensure reverse compatibility for https://github.com/PowerDNS/pdns/pull/7820
+- name: Get installed packages facts
+  package_facts:
+    manager: auto
+
+# Grab the version of dnsdist
+- name: Get dnsdist package version
+  set_fact:
+    _dnsdist_installed_version: "{{ ansible_facts.packages[dnsdist_package_name][0].version }}"
+  when: dnsdist_package_name in ansible_facts.packages
+
+# Load the default user & group for the dnsdist version
+- name: Get dnsdist user & group ownership defaults
+  set_fact:
+    _default_dnsdist_owner: "{{ default_dnsdist_owner_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')) else default_dnsdist_owner }}"
+    _default_dnsdist_group: "{{ default_dnsdist_group_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')) else default_dnsdist_group }}"
+
+# Use user & group overrides if present, else use the version-specific defaults
+- name: Get dnsdist user & group ownership overrides
+  set_fact:
+    _dnsdist_owner: "{{ dnsdist_config_owner if dnsdist_config_owner | length > 0 else _default_dnsdist_owner }}"
+    _dnsdist_group: "{{ dnsdist_config_group if dnsdist_config_group | length > 0 else _default_dnsdist_group }}"
+
+# Ensure user override is present in the systemd overrides if a dnsdist_config_owner has been specified
+- name: Override systemd User
+  set_fact:
+    dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'User': dnsdist_config_owner } ) }}"
+  when: dnsdist_config_owner | length > 0
+
+# Ensure group override is present in the systemd overrides if a dnsdist_config_group has been specified
+- name: Override systemd Group
+  set_fact:
+    dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'Group': dnsdist_config_group } ) }}"
+  when: dnsdist_config_group | length > 0
+
+# Override default ExecStart on RedHat OS family if a dnsdist_config_owner has been specified
+# Default setting which will be overwritten is: ExecStart=/usr/bin/dnsdist -u dnsdist -g dnsdist --supervised --disable-syslog
+- name: Override default ExecStart on RedHat OS family
+  set_fact:
+    dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStart': '/usr/bin/dnsdist --supervised --disable-syslog' } ) }}"
+  when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'RedHat'
+
+# Override default ExecStartPre on RedHat OS family if a dnsdist_config_owner has been specified
+# Default setting which will be overwritten is: ExecStartPre=/usr/bin/dnsdist -u dnsdist -g dnsdist --check-config
+- name: Override default ExecStartPre on RedHat OS family
+  set_fact:
+    dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStartPre': '/usr/bin/dnsdist --check-config' } ) }}"
+  when: dnsdist_config_owner | length > 0 and 'ExecStartPre' not in dnsdist_service_overrides and ansible_os_family == 'RedHat'
+
+# Override default ExecStart on Debian OS family if a dnsdist_config_owner has been specified
+# Default setting which will be overwritten is: ExecStart=/usr/bin/dnsdist --supervised --disable-syslog -u _dnsdist -g _dnsdist
+- name: Override default ExecStart on Debian OS family for dnsdist < 1.5
+  set_fact:
+    dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStart': '/usr/bin/dnsdist --supervised --disable-syslog' } ) }}"
+  when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'Debian' and _dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -20,7 +20,7 @@
   package:
     name: yum-plugin-priorities
     state: present
-  when: ansible_distribution in [ 'CentOS' ]
+  when: ansible_distribution in [ 'CentOS' ] and ansible_pkg_mgr in [ 'yum' ]
 
 - name: Add the dnsdist YUM Repository
   yum_repository:
@@ -30,7 +30,7 @@
     baseurl: "{{ dnsdist_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ dnsdist_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
 
 - name: Add the dnsdist debug symbols YUM Repository
@@ -41,6 +41,6 @@
     baseurl: "{{ dnsdist_install_repo['yum_debug_symbols_repo_baseurl'] }}"
     gpgkey: "{{ dnsdist_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
   when: dnsdist_install_debug_symbols_package

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,4 +1,7 @@
 [Service]
 {% for k, v in dnsdist_service_overrides.items() %}
+{% if k == 'ExecStart' %}ExecStart=
+{% elif k == 'ExecStartPre' %}ExecStartPre=
+{% endif %}
 {{ k }}={{ v }}
 {% endfor %}

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,6 +1,4 @@
 [Service]
 {% for k, v in dnsdist_service_overrides.items() %}
-{% if k == 'ExecStart' %}ExecStart=
-{% endif %}
 {{ k }}={{ v }}
 {% endfor %}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
-molecule==2.19.0
+molecule<3.1
 docker-py==1.10.6
+testinfra<5.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{25,26,27}
+envlist = py{36}-ansible{27,28,29}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.5: ansible25
-  2.6: ansible26
   2.7: ansible27
+  2.8: ansible28
+  2.9: ansible29
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible25: ansible<2.6
-    ansible26: ansible<2.7
     ansible27: ansible<2.8
+    ansible28: ansible<2.9
+    ansible29: ansible<2.10
 commands =
     {posargs:molecule test --all --destroy always}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,6 +9,10 @@ default_dnsdist_debug_symbols_package_name: "{% if ansible_distribution == 'Debi
 # The default location of the config file
 default_dnsdist_config_location: "/etc/dnsdist/dnsdist.conf"
 
-# The default owner/group of the process and files
-default_dnsdist_owner: "root"
-default_dnsdist_group: "root"
+# The default owner/group of the process and files: 1.5 and beyond
+default_dnsdist_owner: "_dnsdist"
+default_dnsdist_group: "_dnsdist"
+
+# The default owner/group of the process and files: 1.4 and earlier
+default_dnsdist_owner_pre15: "root"
+default_dnsdist_group_pre15: "root"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -3,8 +3,13 @@
 # The name of the dnsdist package
 default_dnsdist_package_name: "dnsdist"
 
+# The default location of the config file
 default_dnsdist_config_location: "/usr/local/etc/dnsdist.conf"
 
-# The default owner/group of the process and files
-default_dnsdist_owner: "root"
-default_dnsdist_group: "wheel"
+# The default owner/group of the process and files: 1.5 and beyond
+default_dnsdist_owner: "dnsdist"
+default_dnsdist_group: "dnsdist"
+
+# The default owner/group of the process and files: 1.4 and earlier
+default_dnsdist_owner_pre15: "root"
+default_dnsdist_group_pre15: "wheel"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,6 +9,10 @@ default_dnsdist_debug_symbols_package_name: "dnsdist-debuginfo"
 # The default location of the config file
 default_dnsdist_config_location: "/etc/dnsdist/dnsdist.conf"
 
-# The default owner/group of the process and files
-default_dnsdist_owner: "root"
-default_dnsdist_group: "root"
+# The default owner/group of the process and files: 1.5 and beyond
+default_dnsdist_owner: "dnsdist"
+default_dnsdist_group: "dnsdist"
+
+# The default owner/group of the process and files: 1.4 and earlier
+default_dnsdist_owner_pre15: "root"
+default_dnsdist_group_pre15: "root"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -53,3 +53,12 @@ dnsdist_powerdns_repo_14:
   yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14"
   yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14/debug"
   name: "powerdns-dnsdist-14"
+
+dnsdist_powerdns_repo_15:
+  apt_repo_origin: "repo.powerdns.com"
+  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-15 main"
+  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
+  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15"
+  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15/debug"
+  name: "powerdns-dnsdist-15"


### PR DESCRIPTION
Includes:
- xgin's PR 25 to add 1.5 repo support
- Backwards compatibility changes regarding user & group ownership, to handle dnsdist 1.5 default user changes
- Updates to the test setup (newer Ansible versions, newer Python version, updated travis and more recent OS flavors versions