### PR TITLE
Fix CI and improve Linter coverage

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+exclude_paths:
+  - molecule/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
+---
 exclude_paths:
   - molecule/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 ---
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   Lint:
@@ -17,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - '2.11'
-          - '2.12'
-          - '2.13'
+          - "2.11"
+          - "2.12"
+          - "2.13"
         scenario:
           - dnsdist-14
           - dnsdist-15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,12 @@ jobs:
     name: Test role
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         ansible:
-          - '2.9'
-          - '2.10'
           - '2.11'
+          - '2.12'
+          - '2.13'
         scenario:
           - dnsdist-14
           - dnsdist-15
@@ -24,7 +25,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
 
 jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ansible-lint
+        uses: ansible-community/ansible-lint-action@main
   Tests:
     name: Test role
     runs-on: ubuntu-20.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-
 os: linux
 dist: focal
 language: python

--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,7 @@
+---
 extends: default
 
 rules:
-
   # Disable line-length and truthy values reporting
   line-length: disable
   truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,14 +58,14 @@ dnsdist_install_debug_symbols_package: false
 dnsdist_debug_symbols_package_name: "{{ default_dnsdist_debug_symbols_package_name }}"
 
 # dnsdist listen addresses
-dnsdist_locals: [127.0.0.1:5300]
+dnsdist_locals: ["127.0.0.1:5300"]
 # dnsdist backend servers
 dnsdist_servers: []
 # Access Control List
 dnsdist_acls: []
 # dnsdist's control socket encryption key.
 # See https://dnsdist.org/reference/config.html#setKey for more information.
-dnsdist_generatekey: "{{ (dnsdist_setkey is defined)|bool and (dnsdist_setkey != '' )|bool }}"
+dnsdist_generatekey: "{{ (dnsdist_setkey is defined) | bool and (dnsdist_setkey != '' ) | bool }}"
 
 # dnsdist's control socket list address.
 dnsdist_controlsocket: 127.0.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # By default no additional repository is added to the hosts to install dnsdist
 dnsdist_install_repo: ""
 
@@ -42,7 +41,7 @@ dnsdist_install_repo: ""
 
 # Install the EPEL repository.
 # EPEL is needed to satisfy some dnsdist dependencies like libsodium
-dnsdist_install_epel: True
+dnsdist_install_epel: true
 
 # The name of the dnsdist package
 dnsdist_package_name: "{{ default_dnsdist_package_name }}"
@@ -53,26 +52,23 @@ dnsdist_package_name: "{{ default_dnsdist_package_name }}"
 dnsdist_package_version: ""
 
 # Install dnsdist debug symbols package
-dnsdist_install_debug_symbols_package: False
+dnsdist_install_debug_symbols_package: false
 
 # The name of the dnsdist debug symbols package
 dnsdist_debug_symbols_package_name: "{{ default_dnsdist_debug_symbols_package_name }}"
 
 # dnsdist listen addresses
-dnsdist_locals: ['127.0.0.1:5300']
-
+dnsdist_locals: [127.0.0.1:5300]
 # dnsdist backend servers
 dnsdist_servers: []
-
 # Access Control List
 dnsdist_acls: []
-
 # dnsdist's control socket encryption key.
 # See https://dnsdist.org/reference/config.html#setKey for more information.
 dnsdist_generatekey: "{{ (dnsdist_setkey is defined)|bool and (dnsdist_setkey != '' )|bool }}"
 
 # dnsdist's control socket list address.
-dnsdist_controlsocket: "127.0.0.1"
+dnsdist_controlsocket: 127.0.0.1
 
 # Embedded webserver listen address.
 dnsdist_webserver_address: ""
@@ -101,17 +97,16 @@ dnsdist_service_overrides: {}
 #   LimitNOFILE: 10000
 
 # State of the DNSdist service
-dnsdist_service_state: "started"
+dnsdist_service_state: started
 dnsdist_service_enabled: "yes"
 
 # When True, disable the automated restart of the dnsdist service
-dnsdist_disable_handlers: False
+dnsdist_disable_handlers: false
 
 # When set, adds a DNS over TLS frontend
 dnsdist_tlslocals: []
-
 # When set to True, remove dnsdist packages and force a reinstall
 # Not recommended for regular usage; Primarily intended for 2 scenario's:
 # - Force a downgrade
 # - Automation of test scenario's where switching between versions on the same server is necessary
-dnsdist_force_reinstall: False
+dnsdist_force_reinstall: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # the sleep in the restart dnsdist handler
 # is needed to make sure the service has been
 # correctly stopped before being started again during restarts
@@ -9,8 +8,7 @@
     name: dnsdist
     state: restarted
     sleep: 1
-  when: dnsdist_service_state != 'stopped' and
-    not dnsdist_disable_handlers
+  when: dnsdist_service_state != 'stopped' and not dnsdist_disable_handlers
 
 - name: reload systemd and restart dnsdist
   command: systemctl daemon-reload

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,13 +4,18 @@
 # correctly stopped before being started again during restarts
 
 - name: restart dnsdist
-  service:
+  ansible.builtin.service:
     name: dnsdist
     state: restarted
     sleep: 1
   when: dnsdist_service_state != 'stopped' and not dnsdist_disable_handlers
 
 - name: reload systemd and restart dnsdist
-  command: systemctl daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: true
   notify: restart dnsdist
   when: not dnsdist_disable_handlers
+
+- name: Update the APT cache
+  ansible.builtin.apt:
+    update_cache: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
 galaxy_info:
+  role_name: dnsdist
+  namespace: powerdns
   author: PowerDNS Engineering Team
   description: Dnsdist is a highly scriptable and DDoS aware DNS loadbalancer
   company: PowerDNS.COM BV

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,12 +6,12 @@ galaxy_info:
   description: Dnsdist is a highly scriptable and DDoS aware DNS loadbalancer
   company: PowerDNS.COM BV
   license: MIT
-  min_ansible_version: 2.5
+  min_ansible_version: "2.5"
   platforms:
     - name: EL
       versions:
-        - 7
-        - 8
+        - "7"
+        - "8"
     - name: Debian
       versions:
         - jessie

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,4 @@
 ---
-
 galaxy_info:
   role_name: dnsdist
   namespace: powerdns

--- a/molecule/dnsdist-14/converge.yml
+++ b/molecule/dnsdist-14/converge.yml
@@ -5,4 +5,4 @@
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-14.yml
   roles:
-    - { role: dnsdist-ansible }
+    - { role: powerdns.dnsdist }

--- a/molecule/dnsdist-15/converge.yml
+++ b/molecule/dnsdist-15/converge.yml
@@ -5,4 +5,4 @@
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-15.yml
   roles:
-    - { role: dnsdist-ansible }
+    - { role: powerdns.dnsdist }

--- a/molecule/dnsdist-15/molecule.yml
+++ b/molecule/dnsdist-15/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     dockerfile_tpl: centos-systemd
 
   - name: centos-8
-    image: centos:8
+    image: quay.io/centos/centos:stream8
     dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804

--- a/molecule/dnsdist-16/converge.yml
+++ b/molecule/dnsdist-16/converge.yml
@@ -5,4 +5,4 @@
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-16.yml
   roles:
-    - { role: dnsdist-ansible }
+    - { role: powerdns.dnsdist }

--- a/molecule/dnsdist-16/molecule.yml
+++ b/molecule/dnsdist-16/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     dockerfile_tpl: centos-systemd
 
   - name: centos-8
-    image: centos:8
+    image: quay.io/centos/centos:stream8
     dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804

--- a/molecule/dnsdist-master/converge.yml
+++ b/molecule/dnsdist-master/converge.yml
@@ -5,4 +5,4 @@
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-master.yml
   roles:
-    - { role: dnsdist-ansible }
+    - { role: powerdns.dnsdist }

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     dockerfile_tpl: centos-systemd
 
   - name: centos-8
-    image: centos:8
+    image: quay.io/centos/centos:stream8
     dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -21,17 +21,20 @@
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_facts:
+      community.docker.docker_image_info:
         name: "molecule_dnsdist/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
-      docker_image:
-        path: "{{ molecule_ephemeral_directory }}"
+      community.docker.docker_image:
         name: "molecule_dnsdist/{{ item.item.image }}"
-        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
-        force: "{{ item.item.force | default(True) }}"
+        source: build
+        build:
+          dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+          path: "{{ molecule_ephemeral_directory }}"
+        force_source: "{{ item.item.force | default(True) }}"
+        force_tag: "{{ item.item.force | default(True) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,25 +1,21 @@
 ---
-
-
 - block:
+    - name: Ensure the override directory exists (systemd)
+      file:
+        name: /etc/systemd/system/dnsdist.service.d
+        state: directory
+        owner: "{{ _dnsdist_owner }}"
+        group: "{{ _dnsdist_group }}"
 
-  - name: Ensure the override directory exists (systemd)
-    file:
-      name: "/etc/systemd/system/dnsdist.service.d"
-      state: directory
-      owner: "{{ _dnsdist_owner }}"
-      group: "{{ _dnsdist_group }}"
+    - name: Override the dnsdist unit (systemd)
+      template:
+        src: override-service.systemd.conf.j2
+        dest: /etc/systemd/system/dnsdist.service.d/override.conf
+        owner: "{{ _dnsdist_owner }}"
+        group: "{{ _dnsdist_group }}"
+      notify: reload systemd and restart dnsdist
 
-  - name: Override the dnsdist unit (systemd)
-    template:
-      src: "override-service.systemd.conf.j2"
-      dest: "/etc/systemd/system/dnsdist.service.d/override.conf"
-      owner: "{{ _dnsdist_owner }}"
-      group: "{{ _dnsdist_group }}"
-    notify: reload systemd and restart dnsdist
-
-  when: dnsdist_service_overrides != {}
-    and ansible_service_mgr == "systemd"
+  when: dnsdist_service_overrides != {} and ansible_service_mgr == "systemd"
 
 - name: Add the dnsdist configuration
   template:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,24 +1,27 @@
 ---
-- block:
+- name: Set up systemd override
+  block:
     - name: Ensure the override directory exists (systemd)
-      file:
+      ansible.builtin.file:
         name: /etc/systemd/system/dnsdist.service.d
         state: directory
         owner: "{{ _dnsdist_owner }}"
         group: "{{ _dnsdist_group }}"
+        mode: 0755
 
     - name: Override the dnsdist unit (systemd)
-      template:
+      ansible.builtin.template:
         src: override-service.systemd.conf.j2
         dest: /etc/systemd/system/dnsdist.service.d/override.conf
         owner: "{{ _dnsdist_owner }}"
         group: "{{ _dnsdist_group }}"
+        mode: 0644
       notify: reload systemd and restart dnsdist
 
   when: dnsdist_service_overrides != {} and ansible_service_mgr == "systemd"
 
 - name: Add the dnsdist configuration
-  template:
+  ansible.builtin.template:
     src: dnsdist.conf.j2
     dest: "{{ default_dnsdist_config_location }}"
     owner: "{{ _dnsdist_owner }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,16 +1,14 @@
 ---
-
 - block:
+    - name: Prefix the version with the correct separator on RedHat
+      set_fact:
+        _dnsdist_package_version: -{{ dnsdist_package_version }}
+      when: ansible_os_family == 'RedHat'
 
-  - name: Prefix the version with the correct separator on RedHat
-    set_fact:
-      _dnsdist_package_version: "-{{ dnsdist_package_version }}"
-    when: ansible_os_family == 'RedHat'
-
-  - name: Prefix the version with the correct separator on Debian
-    set_fact:
-      _dnsdist_package_version: "={{ dnsdist_package_version }}"
-    when: ansible_os_family == 'Debian'
+    - name: Prefix the version with the correct separator on Debian
+      set_fact:
+        _dnsdist_package_version: ={{ dnsdist_package_version }}
+      when: ansible_os_family == 'Debian'
 
   when: dnsdist_package_version != ''
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,36 +1,37 @@
 ---
-- block:
+- name: Set up version seperator
+  block:
     - name: Prefix the version with the correct separator on RedHat
-      set_fact:
+      ansible.builtin.set_fact:
         _dnsdist_package_version: -{{ dnsdist_package_version }}
       when: ansible_os_family == 'RedHat'
 
     - name: Prefix the version with the correct separator on Debian
-      set_fact:
+      ansible.builtin.set_fact:
         _dnsdist_package_version: ={{ dnsdist_package_version }}
       when: ansible_os_family == 'Debian'
 
   when: dnsdist_package_version != ''
 
 - name: Remove dnsdist if reinstall is forced
-  package:
+  ansible.builtin.package:
     name: "{{ dnsdist_package_name }}"
     state: absent
   when: dnsdist_force_reinstall | bool
 
 - name: Remove dnsdist debug symbols if reinstall is forced
-  package:
+  ansible.builtin.package:
     name: "{{ dnsdist_debug_symbols_package_name }}"
     state: absent
   when: dnsdist_force_reinstall | bool
 
 - name: Install dnsdist
-  package:
+  ansible.builtin.package:
     name: "{{ dnsdist_package_name }}{{ _dnsdist_package_version | default('') }}"
     state: present
 
 - name: Install dnsdist debug symbols
-  package:
+  ansible.builtin.package:
     name: "{{ dnsdist_debug_symbols_package_name }}{{ _dnsdist_package_version | default('') }}"
     state: present
   when: dnsdist_install_debug_symbols_package | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS-specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - always
 
@@ -17,25 +17,25 @@
 - name: Create encryption key
   block:
     - name: Check if the key is already present in the DNSdist configuration file
-      shell: fgrep setKey "{{ default_dnsdist_config_location }}" | sed 's/setKey("\(.*\)")/\1/'
+      ansible.builtin.shell: fgrep setKey "{{ default_dnsdist_config_location }}" | sed 's/setKey("\(.*\)")/\1/'
       register: dnsdist_grepkey_cmd
       changed_when: false
       failed_when: false
 
-    - block:
-        - name: Generate encryption key
-          shell: head -c 32 /dev/urandom | base64
+    - name: Set up new encryption key
+      block:
+        - name: Generate encryption key  # noqa no-changed-when
+          ansible.builtin.shell: head -c 32 /dev/urandom | base64
           register: dnsdist_setkey_cmd
 
         - name: base64 encode encyption key
-          set_fact:
+          ansible.builtin.set_fact:
             dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
       # if the config file does not contains a key already
       when: dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0
-    - block:
-        - name: Set old encryption key
-          set_fact:
-            dnsdist_setkey: "{{ dnsdist_grepkey_cmd.stdout }}"
+    - name: Set old encryption key
+      ansible.builtin.set_fact:
+        dnsdist_setkey: "{{ dnsdist_grepkey_cmd.stdout }}"
       when: dnsdist_grepkey_cmd.rc == 0 and dnsdist_grepkey_cmd.stdout | length > 0
   when: dnsdist_generatekey
   tags:
@@ -51,7 +51,7 @@
     - configure
 
 - name: Set the status of the dnsdist service
-  service:
+  ansible.builtin.service:
     name: dnsdist
     state: "{{ dnsdist_service_state }}"
     enabled: "{{ dnsdist_service_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-
 - name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - always
 
-- include: "repo-{{ ansible_os_family }}.yml"
+- include: repo-{{ ansible_os_family }}.yml
   when: dnsdist_install_repo != ""
   tags:
     - install
@@ -32,12 +31,12 @@
           set_fact:
             dnsdist_setkey: "{{ dnsdist_setkey_cmd.stdout }}"
       # if the config file does not contains a key already
-      when: "dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0"
+      when: dnsdist_grepkey_cmd.rc > 0 or dnsdist_grepkey_cmd.stdout | length == 0
     - block:
         - name: Set old encryption key
           set_fact:
             dnsdist_setkey: "{{ dnsdist_grepkey_cmd.stdout }}"
-      when: "dnsdist_grepkey_cmd.rc == 0 and dnsdist_grepkey_cmd.stdout | length > 0"
+      when: dnsdist_grepkey_cmd.rc == 0 and dnsdist_grepkey_cmd.stdout | length > 0
   when: dnsdist_generatekey
   tags:
     - install

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -13,8 +13,10 @@
 # Load the default user & group for the dnsdist version
 - name: Get dnsdist user & group ownership defaults
   set_fact:
-    _default_dnsdist_owner: "{{ default_dnsdist_owner_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')) else default_dnsdist_owner }}"
-    _default_dnsdist_group: "{{ default_dnsdist_group_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')) else default_dnsdist_group }}"
+    _default_dnsdist_owner: "{{ default_dnsdist_owner_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt'))\
+      \ else default_dnsdist_owner }}"
+    _default_dnsdist_group: "{{ default_dnsdist_group_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt'))\
+      \ else default_dnsdist_group }}"
 
 # Use user & group overrides if present, else use the version-specific defaults
 - name: Get dnsdist user & group ownership overrides
@@ -53,4 +55,5 @@
 - name: Override default ExecStart on Debian OS family for dnsdist < 1.5
   set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStart': '/usr/bin/dnsdist --supervised --disable-syslog' } ) }}"
-  when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'Debian' and _dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt')
+  when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'Debian' and _dnsdist_installed_version is defined
+    and _dnsdist_installed_version is version('1.5', operator='lt')

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,18 +1,18 @@
 ---
 # Version-related steps regarding user & group ownership to ensure reverse compatibility for https://github.com/PowerDNS/pdns/pull/7820
 - name: Get installed packages facts
-  package_facts:
+  ansible.builtin.package_facts:
     manager: auto
 
 # Grab the version of dnsdist
 - name: Get dnsdist package version
-  set_fact:
+  ansible.builtin.set_fact:
     _dnsdist_installed_version: "{{ ansible_facts.packages[dnsdist_package_name][0].version }}"
   when: dnsdist_package_name in ansible_facts.packages
 
 # Load the default user & group for the dnsdist version
 - name: Get dnsdist user & group ownership defaults
-  set_fact:
+  ansible.builtin.set_fact:
     _default_dnsdist_owner: "{{ default_dnsdist_owner_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt'))\
       \ else default_dnsdist_owner }}"
     _default_dnsdist_group: "{{ default_dnsdist_group_pre15 if (_dnsdist_installed_version is defined and _dnsdist_installed_version is version('1.5', operator='lt'))\
@@ -20,40 +20,40 @@
 
 # Use user & group overrides if present, else use the version-specific defaults
 - name: Get dnsdist user & group ownership overrides
-  set_fact:
+  ansible.builtin.set_fact:
     _dnsdist_owner: "{{ dnsdist_config_owner if dnsdist_config_owner | length > 0 else _default_dnsdist_owner }}"
     _dnsdist_group: "{{ dnsdist_config_group if dnsdist_config_group | length > 0 else _default_dnsdist_group }}"
 
 # Ensure user override is present in the systemd overrides if a dnsdist_config_owner has been specified
 - name: Override systemd User
-  set_fact:
+  ansible.builtin.set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'User': dnsdist_config_owner } ) }}"
   when: dnsdist_config_owner | length > 0
 
 # Ensure group override is present in the systemd overrides if a dnsdist_config_group has been specified
 - name: Override systemd Group
-  set_fact:
+  ansible.builtin.set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'Group': dnsdist_config_group } ) }}"
   when: dnsdist_config_group | length > 0
 
 # Override default ExecStart on RedHat OS family if a dnsdist_config_owner has been specified
 # Default setting which will be overwritten is: ExecStart=/usr/bin/dnsdist -u dnsdist -g dnsdist --supervised --disable-syslog
 - name: Override default ExecStart on RedHat OS family
-  set_fact:
+  ansible.builtin.set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStart': '/usr/bin/dnsdist --supervised --disable-syslog' } ) }}"
   when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'RedHat'
 
 # Override default ExecStartPre on RedHat OS family if a dnsdist_config_owner has been specified
 # Default setting which will be overwritten is: ExecStartPre=/usr/bin/dnsdist -u dnsdist -g dnsdist --check-config
 - name: Override default ExecStartPre on RedHat OS family
-  set_fact:
+  ansible.builtin.set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStartPre': '/usr/bin/dnsdist --check-config' } ) }}"
   when: dnsdist_config_owner | length > 0 and 'ExecStartPre' not in dnsdist_service_overrides and ansible_os_family == 'RedHat'
 
 # Override default ExecStart on Debian OS family if a dnsdist_config_owner has been specified
 # Default setting which will be overwritten is: ExecStart=/usr/bin/dnsdist --supervised --disable-syslog -u _dnsdist -g _dnsdist
 - name: Override default ExecStart on Debian OS family for dnsdist < 1.5
-  set_fact:
+  ansible.builtin.set_fact:
     dnsdist_service_overrides: "{{ dnsdist_service_overrides | combine( { 'ExecStart': '/usr/bin/dnsdist --supervised --disable-syslog' } ) }}"
   when: dnsdist_config_owner | length > 0 and 'ExecStart' not in dnsdist_service_overrides and ansible_os_family == 'Debian' and _dnsdist_installed_version is defined
     and _dnsdist_installed_version is version('1.5', operator='lt')

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install gnupg
   package:
     name: gnupg
@@ -21,8 +20,8 @@
 
 - name: Update the APT cache
   apt:
-    update_cache: yes
-  when: "_dnsdist_apt_key.changed or _dnsdist_apt_repo.changed"
+    update_cache: true
+  when: _dnsdist_apt_key.changed or _dnsdist_apt_repo.changed
 
 - name: Pin the dnsdist APT Repository
   template:

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,29 +1,27 @@
 ---
 - name: Install gnupg
-  package:
+  ansible.builtin.package:
     name: gnupg
     state: present
 
 - name: Import the dnsdist APT Repository key
-  apt_key:
+  ansible.builtin.apt_key:
     url: "{{ dnsdist_install_repo['gpg_key'] }}"
     id: "{{ dnsdist_install_repo['gpg_key_id'] | default('') }}"
     state: present
   register: _dnsdist_apt_key
+  notify: Update the APT cache
 
 - name: Add the dnsdist APT Repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     filename: "{{ dnsdist_install_repo['name'] }}"
     repo: "{{ dnsdist_install_repo['apt_repo'] }}"
     state: present
   register: _dnsdist_apt_repo
-
-- name: Update the APT cache
-  apt:
-    update_cache: true
-  when: _dnsdist_apt_key.changed or _dnsdist_apt_repo.changed
+  notify: Update the APT cache
 
 - name: Pin the dnsdist APT Repository
-  template:
+  ansible.builtin.template:
     src: dnsdist.pin.j2
     dest: /etc/apt/preferences.d/dnsdist
+    mode: u=rw,g=r,o=r

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -1,18 +1,16 @@
 ---
-
 - block:
+    - name: Install epel-release on CentOS
+      package:
+        name: epel-release
+        state: present
+      when: ansible_distribution in [ 'CentOS' ]
 
-  - name: Install epel-release on CentOS
-    package:
-      name: epel-release
-      state: present
-    when: ansible_distribution in [ 'CentOS' ]
-
-  - name: Install epel-release on RHEL/OracleLinux
-    package:
-      name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-      state: present
-    when: ansible_distribution in [ 'RedHat', 'OracleLinux' ]
+    - name: Install epel-release on RHEL/OracleLinux
+      package:
+        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+        state: present
+      when: ansible_distribution in [ 'RedHat', 'OracleLinux' ]
 
   when: dnsdist_install_epel
 
@@ -29,7 +27,7 @@
     description: PowerDNS dnsdist Repository
     baseurl: "{{ dnsdist_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ dnsdist_install_repo['gpg_key'] }}"
-    gpgcheck: yes
+    gpgcheck: true
     priority: "90"
     state: present
 
@@ -40,7 +38,7 @@
     description: PowerDNS dnsdist Repository - debug symbols
     baseurl: "{{ dnsdist_install_repo['yum_debug_symbols_repo_baseurl'] }}"
     gpgkey: "{{ dnsdist_install_repo['gpg_key'] }}"
-    gpgcheck: yes
+    gpgcheck: true
     priority: "90"
     state: present
   when: dnsdist_install_debug_symbols_package

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -1,13 +1,14 @@
 ---
-- block:
+- name: Set up EPEL
+  block:
     - name: Install epel-release on CentOS
-      package:
+      ansible.builtin.package:
         name: epel-release
         state: present
       when: ansible_distribution in [ 'CentOS' ]
 
     - name: Install epel-release on RHEL/OracleLinux
-      package:
+      ansible.builtin.package:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
       when: ansible_distribution in [ 'RedHat', 'OracleLinux' ]
@@ -15,13 +16,13 @@
   when: dnsdist_install_epel
 
 - name: Install yum-plugin-priorities
-  package:
+  ansible.builtin.package:
     name: yum-plugin-priorities
     state: present
   when: ansible_distribution in [ 'CentOS' ] and ansible_pkg_mgr in [ 'yum' ]
 
 - name: Add the dnsdist YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ dnsdist_install_repo['name'] }}"
     file: "{{ dnsdist_install_repo['name'] }}"
     description: PowerDNS dnsdist Repository
@@ -32,7 +33,7 @@
     state: present
 
 - name: Add the dnsdist debug symbols YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ dnsdist_install_repo['name'] }}-debuginfo"
     file: "{{ dnsdist_install_repo['name'] }}"
     description: PowerDNS dnsdist Repository - debug symbols

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
-jinja2==2.11.3
-ansible-lint==5.0.7
+ansible-lint==5.4.0
 yamllint==1.26.1
-molecule[docker]==3.3.0
-molecule[lint]==3.3.0
-testinfra
-docker==5.0.0
+molecule[docker]==4.0.0
+molecule[lint]==4.0.0
+pytest-testinfra==6.7.0
+docker==5.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 1.8
-envlist = ansible{29,210,211}
+envlist = ansible{211,212,213}
 skipsdist = true
 
 [gh-actions:env]
 ANSIBLE=
-  2.9: ansible29
-  2.10: ansible210
   2.11: ansible211
+  2.12: ansible212
+  2.13: ansible213
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible29: ansible<2.10
-    ansible210: ansible<2.11
-    ansible211: ansible<2.12
+    ansible211: ansible-core<2.12
+    ansible212: ansible-core<2.13
+    ansible213: ansible-core<2.14
 setenv =
   PY_COLORS = 1
 commands =

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,18 +1,18 @@
 ---
-
 # The name of the dnsdist package
-default_dnsdist_package_name: "dnsdist"
+default_dnsdist_package_name: dnsdist
 
 # The name of the dnsdist debug package
-default_dnsdist_debug_symbols_package_name: "{% if ansible_distribution == 'Debian' and ansible_distribution_version | int < 9 or ansible_distribution == 'Ubuntu' and ansible_distribution_version <= '16.04' %}dnsdist-dbg{% else %}dnsdist-dbgsym{% endif %}"
+default_dnsdist_debug_symbols_package_name: "{% if ansible_distribution == 'Debian' and ansible_distribution_version | int < 9 or ansible_distribution == 'Ubuntu'\
+  \ and ansible_distribution_version <= '16.04' %}dnsdist-dbg{% else %}dnsdist-dbgsym{% endif %}"
 
 # The default location of the config file
-default_dnsdist_config_location: "/etc/dnsdist/dnsdist.conf"
+default_dnsdist_config_location: /etc/dnsdist/dnsdist.conf
 
 # The default owner/group of the process and files: 1.5 and beyond
-default_dnsdist_owner: "_dnsdist"
-default_dnsdist_group: "_dnsdist"
+default_dnsdist_owner: _dnsdist
+default_dnsdist_group: _dnsdist
 
 # The default owner/group of the process and files: 1.4 and earlier
-default_dnsdist_owner_pre15: "root"
-default_dnsdist_group_pre15: "root"
+default_dnsdist_owner_pre15: root
+default_dnsdist_group_pre15: root

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,15 +1,14 @@
 ---
-
 # The name of the dnsdist package
-default_dnsdist_package_name: "dnsdist"
+default_dnsdist_package_name: dnsdist
 
 # The default location of the config file
-default_dnsdist_config_location: "/usr/local/etc/dnsdist.conf"
+default_dnsdist_config_location: /usr/local/etc/dnsdist.conf
 
 # The default owner/group of the process and files: 1.5 and beyond
-default_dnsdist_owner: "dnsdist"
-default_dnsdist_group: "dnsdist"
+default_dnsdist_owner: dnsdist
+default_dnsdist_group: dnsdist
 
 # The default owner/group of the process and files: 1.4 and earlier
-default_dnsdist_owner_pre15: "root"
-default_dnsdist_group_pre15: "wheel"
+default_dnsdist_owner_pre15: root
+default_dnsdist_group_pre15: wheel

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,18 +1,17 @@
 ---
-
 # The name of the dnsdist package
-default_dnsdist_package_name: "dnsdist"
+default_dnsdist_package_name: dnsdist
 
 # The name of the dnsdist debug package
-default_dnsdist_debug_symbols_package_name: "dnsdist-debuginfo"
+default_dnsdist_debug_symbols_package_name: dnsdist-debuginfo
 
 # The default location of the config file
-default_dnsdist_config_location: "/etc/dnsdist/dnsdist.conf"
+default_dnsdist_config_location: /etc/dnsdist/dnsdist.conf
 
 # The default owner/group of the process and files: 1.5 and beyond
-default_dnsdist_owner: "dnsdist"
-default_dnsdist_group: "dnsdist"
+default_dnsdist_owner: dnsdist
+default_dnsdist_group: dnsdist
 
 # The default owner/group of the process and files: 1.4 and earlier
-default_dnsdist_owner_pre15: "root"
-default_dnsdist_group_pre15: "root"
+default_dnsdist_owner_pre15: root
+default_dnsdist_group_pre15: root

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,37 +1,36 @@
 ---
-
 dnsdist_powerdns_repo_master:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-master main"
-  gpg_key: "http://repo.powerdns.com/CBC8B383-pub.asc"
-  gpg_key_id: "D47975F8DAE32700A563E64FFF389421CBC8B383"
-  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-master"
-  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-master/debug"
-  name: "powerdns-dnsdist-master"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-master main
+  gpg_key: http://repo.powerdns.com/CBC8B383-pub.asc
+  gpg_key_id: D47975F8DAE32700A563E64FFF389421CBC8B383
+  yum_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-master
+  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-master/debug
+  name: powerdns-dnsdist-master
 
 dnsdist_powerdns_repo_14:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-14 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14"
-  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14/debug"
-  name: "powerdns-dnsdist-14"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-14 main
+  gpg_key: http://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14
+  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-14/debug
+  name: powerdns-dnsdist-14
 
 dnsdist_powerdns_repo_15:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-15 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15"
-  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15/debug"
-  name: "powerdns-dnsdist-15"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-15 main
+  gpg_key: http://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15
+  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15/debug
+  name: powerdns-dnsdist-15
 
 dnsdist_powerdns_repo_16:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-16 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-16"
-  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-16/debug"
-  name: "powerdns-dnsdist-16"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-dnsdist-16 main
+  gpg_key: http://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-16
+  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-16/debug
+  name: powerdns-dnsdist-16


### PR DESCRIPTION
What I did:
* Fixed the existing CI build
* Added a separate `ansible-lint` task
* Made the linter happy

This currently ignores the molecule stuff which could be added later.
I also did not add any new PowerDNS versions to the CI.

This closes #38 