### PR TITLE
allow for newServer Lua table syntax in dnsdist_servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Configure dnsdist's listen addresses.
 dnsdist_servers: []
 ```
 
-The list of IP addresses of the downstream DNS servers dnsdist should be send traffic to.
+The list of IP addresses of the downstream DNS servers dnsdist should be send traffic to
+OR of Lua tables that the newServer function ( https://dnsdist.org/reference/config.html#newServer ) can parse.
 
 ```yaml
 dnsdist_carbonserver: ""

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ dnsdist_locals: ['127.0.0.1:5300']
 Configure dnsdist's listen addresses.
 
 ```yaml
-dnsdist_servers: []
+dnsdist_servers:
+  - '127.0.0.1'
+  - "{ address='127.0.0.1:5300', source='127.0.0.1@lo', order=1 }"
 ```
 
 The list of IP addresses of the downstream DNS servers dnsdist should be send traffic to

--- a/templates/dnsdist.conf.j2
+++ b/templates/dnsdist.conf.j2
@@ -11,7 +11,11 @@ addACL("{{acl}}")
 {% endfor %}
 
 {% for server in dnsdist_servers %}
+{% if "{" in server %}
+newServer({{server}})
+{% else %}
 newServer("{{server}}")
+{% endif %}
 {% endfor %}
 
 {% if dnsdist_controlsocket != "" %}


### PR DESCRIPTION
In order to allow for newServer Lua table style configuration syntax the double quotes have to be omitted if that style is detected.

