### PR TITLE
fix version in yum_debug_symbols_repo_baseurl for v1.7.x

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,5 +32,5 @@ dnsdist_powerdns_repo_17:
   gpg_key: http://repo.powerdns.com/FD380FBB-pub.asc
   gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
   yum_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-17
-  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-15/debug
+  yum_debug_symbols_repo_baseurl: http://repo.powerdns.com/centos/$basearch/$releasever/dnsdist-17/debug
   name: powerdns-dnsdist-17


### PR DESCRIPTION
Noticed that v1.7.x config is missing in Ansible Galaxy. Wanted to add it and saw that it's already there in GitHub master branch but with a typo.

When do you guys think you will be able to release a new Ansible Galaxy version with the latest additions and fixes?
Thanks for your great work on this role!