### PR TITLE
Remove sleep Option from handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,6 @@
   ansible.builtin.service:
     name: dnsdist
     state: restarted
-    sleep: 1
   when: dnsdist_service_state != 'stopped' and not dnsdist_disable_handlers
 
 - name: Update the APT cache


### PR DESCRIPTION
Removed sleep option because doesn't supported in systemd and showing an anyoing warning:
```
Ignoring "sleep" as it is not used in "systemd"
```