### PR TITLE
unbreak CI, bump a few things

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - "2.11"
           - "2.12"
           - "2.13"
+          - "2.14"
         scenario:
           - dnsdist-16
           - dnsdist-17

--- a/molecule/dnsdist-16/molecule.yml
+++ b/molecule/dnsdist-16/molecule.yml
@@ -42,8 +42,7 @@ provisioner:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
-
+  
 lint: yamllint vars tasks defaults meta
 
 verifier:
@@ -54,4 +53,3 @@ verifier:
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-16/
-  lint: flake8

--- a/molecule/dnsdist-17/molecule.yml
+++ b/molecule/dnsdist-17/molecule.yml
@@ -46,7 +46,6 @@ provisioner:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0017
 
 lint: yamllint vars tasks defaults meta
 
@@ -58,4 +57,3 @@ verifier:
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-17/
-  lint: flake8

--- a/molecule/dnsdist-18/molecule.yml
+++ b/molecule/dnsdist-18/molecule.yml
@@ -42,9 +42,8 @@ provisioner:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0017
 
-lint: yamllint vars tasks defaults meta
+#lint: yamllint vars tasks defaults meta
 
 verifier:
   name: testinfra
@@ -54,4 +53,3 @@ verifier:
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-18/
-  lint: flake8

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -26,10 +26,6 @@ platforms:
     image: ubuntu:20.04
     dockerfile_tpl: debian-systemd
 
-  - name: debian-9
-    image: debian:9
-    dockerfile_tpl: debian-systemd
-
   - name: debian-10
     image: debian:10
     dockerfile_tpl: debian-systemd

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -46,7 +46,6 @@ provisioner:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
-  lint: ansible-lint -x ANSIBLE0006 ANSIBLE0016
 
 lint: yamllint vars tasks defaults meta
 
@@ -58,4 +57,3 @@ verifier:
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../repo-master/
-  lint: flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
-ansible-lint==6.16.2
+ansible-lint==6.17.2
 yamllint==1.32.0
 molecule-plugins[docker]==23.4.1
 molecule-plugins[lint]==23.4.1
-molecule==5.0.1
+molecule==5.1.0
 pytest-testinfra==8.1.0
 docker==6.1.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
-ansible-lint==5.4.0
-yamllint==1.29.0
-molecule[docker]==4.0.0
-molecule[lint]==4.0.0
-pytest-testinfra==6.7.0
-docker==5.0.3
+ansible-lint==6.16.2
+yamllint==1.32.0
+molecule-plugins[docker]==23.4.1
+molecule-plugins[lint]==23.4.1
+molecule==5.0.1
+pytest-testinfra==8.1.0
+docker==6.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 1.8
-envlist = ansible{211,212,213}
+envlist = ansible{212,213,214}
 skipsdist = true
 
 [gh-actions:env]
 ANSIBLE=
-  2.11: ansible211
   2.12: ansible212
   2.13: ansible213
+  2.14: ansible214
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible211: ansible-core<2.12
     ansible212: ansible-core<2.13
     ansible213: ansible-core<2.14
+    ansible214: ansible-core<2.15
 setenv =
   PY_COLORS = 1
 commands =


### PR DESCRIPTION
* drop ansible 2.11, add 2.14
* remove lint properties that molecule no longer likes
* pin requirements to newer versions

lint is still unhappy after this