### PR TITLE
alternative fix for #119, removing pipefail

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,7 @@
     - molecule-idempotence-notest
   block:
     - name: Check if the key is already present in the DNSdist configuration file
-      ansible.builtin.shell: |
-        set -o pipefail && fgrep setKey "{{ default_dnsdist_config_location }}" | sed 's/setKey("\(.*\)")/\1/'
+      ansible.builtin.shell: fgrep setKey "{{ default_dnsdist_config_location }}" | sed 's/setKey("\(.*\)")/\1/'
       register: dnsdist_grepkey_cmd
       changed_when: false
       failed_when: false


### PR DESCRIPTION
To me, the pipefail makes little sense, and only works if `/bin/sh` is "bashy enough" to understand that option.

Alternative to #120 