### PR TITLE
GH Actions: fix issues with CI

### DIFF
--- a/molecule/dnsdist-16/molecule.yml
+++ b/molecule/dnsdist-16/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/dnsdist-17/molecule.yml
+++ b/molecule/dnsdist-17/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/dnsdist-18/molecule.yml
+++ b/molecule/dnsdist-18/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/dnsdist-master/molecule.yml
+++ b/molecule/dnsdist-master/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -62,5 +62,5 @@
         privileged: "yes"
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
-          - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+          - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -29,4 +29,4 @@ def test_dnsdist_repo(host):
 def test_dnsdist_version(host):
     cmd = host.run('/usr/bin/dnsdist --version')
 
-    assert re.match('dnsdist \d\.\d\.', cmd.stdout)
+    assert re.match('dnsdist \d+\.\d+\.', cmd.stdout)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ molecule-plugins[docker]==23.4.1
 molecule-plugins[lint]==23.4.1
 molecule==5.1.0
 pytest-testinfra==8.1.0
-docker==6.1.3
+docker==7.1.0


### PR DESCRIPTION
Included in this PR are fixes for:

- Version of `docker-py` set to 7.1.0. Older versions require a specific version of `requests` to work (see [here](https://github.com/docker/docker-py/issues/3256)
- Move from tests from`centos:7` to `oraclelinux:7`
- `test_repo_version`: allow sub-version digits greater than 9 (i.e., `1.10`)
- Mount `/sys/fs/cgroups` as `rw` to overcome the error that made containers fail after starting: `Failed to create /actions_job/b23bdd0759a907717ae61975e6bf5b5044ae8f9dee961e93a4c108e30868f395/init.scope control group: Read-only file system`