### PR TITLE
CI tests: upgraded version of molecule and ansible-core packages

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,4 @@
 ---
-exclude_paths:
-  - molecule/
 skip_list:
   - '306'  # [306] Shells that use pipes should set the pipefail option
+  - 'args' # [args] throws a warning on community.docker.docker_container for a correct attribute (cgroupns_mode)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,21 +7,21 @@ on:
 
 jobs:
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible/ansible-lint@main
   Tests:
-    name: Test role
-    runs-on: ubuntu-20.04
+    name: Test role on different ansible versions
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         ansible:
-          - "2.12"
-          - "2.13"
           - "2.14"
+          - "2.15"
+          - "2.16"
         scenario:
           - dnsdist-16
           - dnsdist-17
@@ -29,11 +29,11 @@ jobs:
           - dnsdist-master
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.yamllint
+++ b/.yamllint
@@ -2,15 +2,31 @@
 extends: default
 
 rules:
-  # Disable line-length and truthy values reporting
-  line-length: disable
-  truthy: disable
-
-  # Max 1 space to separate the elements in brakets
   braces:
     max-spaces-inside: 1
-
-  # Max 1 space in empty brackets
+    level: error
   brackets:
-    min-spaces-inside-empty: 0
-    max-spaces-inside-empty: 1
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/molecule/dnsdist-16/converge.yml
+++ b/molecule/dnsdist-16/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: all
+- name: Dnsdist 1.6
+  hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-16.yml

--- a/molecule/dnsdist-17/converge.yml
+++ b/molecule/dnsdist-17/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: all
+- name: Dnsdist 1.7
+  hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-17.yml

--- a/molecule/dnsdist-18/converge.yml
+++ b/molecule/dnsdist-18/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: all
+- name: Dnsdist 1.8
+  hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-18.yml

--- a/molecule/dnsdist-master/converge.yml
+++ b/molecule/dnsdist-master/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: all
+- name: Dnsdist Master
+  hosts: all
   vars_files:
     - ../resources/vars/dnsdist-common.yml
     - ../resources/vars/dnsdist-repo-master.yml

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -63,4 +63,5 @@
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
           - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+        cgroupns_mode: host
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -8,15 +8,19 @@
     - vars/molecule.yml
   tasks:
 
-    - set_fact:
+    - name: Get list of service instances
+      ansible.builtin.set_fact:
         molecule_service_instances: "{{ molecule_yml.platforms | selectattr('is_service', 'defined') | selectattr('is_service') | list }}"
-    - set_fact:
+
+    - name: Get list of platform instances
+      ansible.builtin.set_fact:
         molecule_platform_instances: "{{ molecule_yml.platforms | difference(molecule_service_instances) }}"
 
     - name: Create Dockerfiles from image names
-      template:
+      ansible.builtin.template:
         src: "Dockerfile.{{ item.dockerfile_tpl | default('default') }}.j2"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+        mode: '0644'
       with_items: "{{ molecule_platform_instances }}"
       register: platforms
 
@@ -39,7 +43,7 @@
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
     - name: Create molecule instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "{{ item.image }}"
@@ -51,7 +55,7 @@
       with_items: "{{ molecule_service_instances }}"
 
     - name: Create the required Services instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "molecule_dnsdist/{{ item.image }}"

--- a/molecule/resources/destroy.yml
+++ b/molecule/resources/destroy.yml
@@ -8,7 +8,7 @@
     - vars/molecule.yml
   tasks:
     - name: Destroy the target Platforms instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         state: absent
         force_kill: "{{ item.force_kill | default(True) }}"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
-ansible-lint==6.17.2
-yamllint==1.32.0
-molecule-plugins[docker]==23.4.1
-molecule-plugins[lint]==23.4.1
-molecule==5.1.0
-pytest-testinfra==8.1.0
+ansible-lint==24.12.2
+yamllint==1.35.1
+molecule-plugins[docker]==23.6.0
+molecule-plugins[lint]==23.6.0
+molecule==24.9.0
+pytest-testinfra==10.1.1
 docker==7.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 1.8
-envlist = ansible{212,213,214}
+envlist = ansible{214,215,216}
 skipsdist = true
 
 [gh-actions:env]
 ANSIBLE=
-  2.12: ansible212
-  2.13: ansible213
   2.14: ansible214
+  2.15: ansible215
+  2.16: ansible216
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible212: ansible-core>2.12,<2.13
-    ansible213: ansible-core>2.13,<2.14
     ansible214: ansible-core>2.14,<2.15
+    ansible215: ansible-core>2.15,<2.16
+    ansible216: ansible-core>2.16,<2.17
 setenv =
   PY_COLORS = 1
 commands =


### PR DESCRIPTION
Tests now run against `ansible-core 2.14, 2.15 and 2.16`.

Fixed some lint issues