### PR TITLE
GH Actions: pin  ansible-compat version to 24.10.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 ansible-lint==24.12.2
+ansible-compat==24.10.0
 yamllint==1.35.1
 molecule-plugins[docker]==23.6.0
 molecule-plugins[lint]==23.6.0


### PR DESCRIPTION
Fixes <https://github.com/PowerDNS/dnsdist-ansible/actions/runs/13107239559/job/36564367333>