### PR TITLE
Add varible `dnsdist_config_files` for add additional configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.6.0 (#UNRELEASED)
+
+NEW FEATURES:
+- Add varible `dnsdist_config_files` for add additional configuration files ([\#145](https://github.com/PowerDNS/dnsdist-ansible/pull/145))
+
 ## v1.5.0 (2023-02-08)
 
 NEW FEATURES:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ dnsdist_config: ""
 Additional dnsdist configuration to be injected verbatim in the `dnsdist.conf` file.
 
 ```yaml
+dnsdist_config_files: {}
+```
+
+Additional dnsdist configuration files to be placed in the configuration directory.
+
+```yaml
 dnsdist_config_owner: 'root'
 dnsdist_config_group: 'root'
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,12 @@ dnsdist_carbonserver: ""
 # injected into dnsdist's configuration file.
 dnsdist_config: ""
 
+# Additional dnsdist configuration files.
+dnsdist_config_files: {}
+# dnsdist_config_files:
+#   extra.conf: |
+#     -- extra file with configration
+
 # Owner and group for /etc/dnsdist/dnsdist.conf
 dnsdist_config_owner: ""
 dnsdist_config_group: ""
@@ -116,6 +122,7 @@ dnsdist_disable_handlers: false
 
 # When set, adds a DNS over TLS frontend
 dnsdist_tlslocals: []
+
 # When set to True, remove dnsdist packages and force a reinstall
 # Not recommended for regular usage; Primarily intended for 2 scenario's:
 # - Force a downgrade

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,3 +52,15 @@
     mode: 0640
     validate: dnsdist -C %s --check-config 2>&1
   notify: Restart dnsdist
+
+- name: Add the dnsdist additional configuration files
+  tags:
+    - molecule-idempotence-notest
+  ansible.builtin.copy:
+    content: "{{ dnsdist_config_files[item] }}"
+    dest: "{{ default_dnsdist_config_location | dirname }}/{{ item }}"
+    owner: "{{ _dnsdist_owner }}"
+    group: "{{ _dnsdist_group }}"
+    mode: 0640
+  with_items: "{{ dnsdist_config_files }}"
+  notify: Restart dnsdist


### PR DESCRIPTION
NEW FEATURES:
- Add varible `dnsdist_config_files` for add additional configuration files ([\#145](https://github.com/PowerDNS/dnsdist-ansible/pull/145))
