### PR TITLE
Change the order of tasks for additional files and configration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ NEW FEATURES:
 - Add variable `dnsdist_config_files` for add additional configuration files ([\#145](https://github.com/PowerDNS/dnsdist-ansible/pull/145))
 - Add variable `dnsdist_additional_packages` for add additional dependency packages. Set `no_log: true` for "Get installed packages facts" task.  ([\#146](https://github.com/PowerDNS/dnsdist-ansible/pull/146))
 
+BUG FIXES:
+- Change the order of tasks for additional files, so it's before the validation of the dnsdist configuration file. Since the configuration file may refer to additional files, they should already exist in the system.
+
 ## v1.5.0 (2023-02-08)
 
 NEW FEATURES:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,18 +41,6 @@
       when: dnsdist_environment_overrides != {}
       notify: Reload systemd and restart dnsdist
 
-- name: Add the dnsdist configuration
-  tags:
-    - molecule-idempotence-notest
-  ansible.builtin.template:
-    src: dnsdist.conf.j2
-    dest: "{{ default_dnsdist_config_location }}"
-    owner: "{{ _dnsdist_owner }}"
-    group: "{{ _dnsdist_group }}"
-    mode: 0640
-    validate: dnsdist -C %s --check-config 2>&1
-  notify: Restart dnsdist
-
 - name: Add the dnsdist additional configuration files
   tags:
     - molecule-idempotence-notest
@@ -63,4 +51,16 @@
     group: "{{ _dnsdist_group }}"
     mode: 0640
   with_items: "{{ dnsdist_config_files }}"
+  notify: Restart dnsdist
+
+- name: Add the dnsdist configuration
+  tags:
+    - molecule-idempotence-notest
+  ansible.builtin.template:
+    src: dnsdist.conf.j2
+    dest: "{{ default_dnsdist_config_location }}"
+    owner: "{{ _dnsdist_owner }}"
+    group: "{{ _dnsdist_group }}"
+    mode: 0640
+    validate: dnsdist -C %s --check-config 2>&1
   notify: Restart dnsdist


### PR DESCRIPTION
BUG FIXES:
- Change the order of tasks for additional files, so it's before the validation of the dnsdist configuration file. Since the configuration file may refer to additional files, they should already exist in the system.