### PR TITLE
Fix error when not using dnsdist_config_files

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -45,12 +45,12 @@
   tags:
     - molecule-idempotence-notest
   ansible.builtin.copy:
-    content: "{{ dnsdist_config_files[item] }}"
-    dest: "{{ default_dnsdist_config_location | dirname }}/{{ item }}"
+    content: "{{ item.value }}"
+    dest: "{{ default_dnsdist_config_location | dirname }}/{{ item.key }}"
     owner: "{{ _dnsdist_owner }}"
     group: "{{ _dnsdist_group }}"
     mode: '0640'
-  with_items: "{{ dnsdist_config_files }}"
+  with_items: "{{ dnsdist_config_files | dict2items }}"
   notify: Restart dnsdist
 
 - name: Add the dnsdist configuration


### PR DESCRIPTION
`dnsdist_config_files` is a dict, but with_items only supports lists.

```
[ERROR]: Task failed: Finalization of task args for 'ansible.builtin.copy' failed: Error while resolving value for 'content': ansible._internal._templating._lazy_containers._AnsibleLazyTemplateDict object has no element {}

Task failed.
Origin: /tmp/Ansible/.ansible/galaxy/roles/powerdns.dnsdist/tasks/configure.yml:44:3

42       notify: Reload systemd and restart dnsdist
43
44 - name: Add the dnsdist additional configuration files
     ^ column 3

<<< caused by >>>

Finalization of task args for 'ansible.builtin.copy' failed.
Origin: /tmp/Ansible/.ansible/galaxy/roles/powerdns.dnsdist/tasks/configure.yml:47:3

45   tags:
46     - molecule-idempotence-notest
47   ansible.builtin.copy:
     ^ column 3

<<< caused by >>>

Error while resolving value for 'content': ansible._internal._templating._lazy_containers._AnsibleLazyTemplateDict object has no element {}
Origin: /tmp/Ansible/.ansible/galaxy/roles/powerdns.dnsdist/tasks/configure.yml:48:14

46     - molecule-idempotence-notest
47   ansible.builtin.copy:
48     content: "{{ dnsdist_config_files[item] }}"
                ^ column 14

failed: [host01] (item={}) => changed=false 
  ansible_loop_var: item
  item: {}
  msg: 'Task failed: Finalization of task args for ''ansible.builtin.copy'' failed: Error while resolving value for ''content'': ansible._internal._templating._lazy_containers._AnsibleLazyTemplateDict object has no element {}'
```